### PR TITLE
Add Cloudflare KV storage

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -18,7 +18,7 @@ from telegram.ext import (
 )
 import pyotp
 from botlib.translations import tr
-from botlib.storage import JSONStorage
+from botlib.storage import WorkerStorage
 
 # Languages that can be used with /setlang
 SUPPORTED_LANGS = {"en", "fa"}
@@ -46,13 +46,13 @@ if not ADMIN_PHONE:
     logger.error("ADMIN_PHONE environment variable not set")
     raise SystemExit("ADMIN_PHONE environment variable not set")
 
-FERNET_KEY = os.environ.get("FERNET_KEY")
-if not FERNET_KEY:
-    logger.error("FERNET_KEY environment variable not set")
-    raise SystemExit("FERNET_KEY environment variable not set")
+WORKER_URL = os.environ.get("WORKER_URL")
+if not WORKER_URL:
+    logger.error("WORKER_URL environment variable not set")
+    raise SystemExit("WORKER_URL environment variable not set")
 
 
-storage = JSONStorage(DATA_FILE, FERNET_KEY.encode())
+storage = WorkerStorage(WORKER_URL)
 data = asyncio.run(storage.load())
 data.setdefault('languages', {})
 

--- a/worker/my-worker/package.json
+++ b/worker/my-worker/package.json
@@ -3,17 +3,20 @@
 	"version": "0.0.0",
 	"private": true,
 	"scripts": {
-        "deploy": "wrangler deploy",
-        "dev": "wrangler dev",
-        "start": "wrangler dev",
-        "test": "vitest",
-        "cf-typegen": "wrangler types",
-        "build": "wrangler build"
+		"deploy": "wrangler deploy",
+		"dev": "wrangler dev",
+		"start": "wrangler dev",
+		"test": "vitest",
+		"cf-typegen": "wrangler types",
+		"build": "wrangler build"
 	},
 	"devDependencies": {
 		"@cloudflare/vitest-pool-workers": "^0.8.19",
 		"typescript": "^5.5.2",
 		"vitest": "~3.2.0",
 		"wrangler": "^4.24.3"
+	},
+	"dependencies": {
+		"fernet": "^0.3.3"
 	}
 }

--- a/worker/my-worker/src/index.ts
+++ b/worker/my-worker/src/index.ts
@@ -12,20 +12,125 @@
  */
 
 interface Env {
-    ADMIN_ID: string
-    ADMIN_PHONE: string
-    FERNET_KEY: string
+    ADMIN_ID: string;
+    ADMIN_PHONE: string;
+    FERNET_KEY: string;
+    DATA: KVNamespace;
+}
+
+interface Data {
+    products: Record<string, Record<string, unknown>>;
+    pending: unknown[];
+    languages: Record<string, string>;
+}
+
+function b64ToBytes(b64: string): Uint8Array {
+    return Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+}
+
+function bytesToB64(bytes: Uint8Array): string {
+    return btoa(String.fromCharCode(...bytes));
+}
+
+async function encryptField(value: string, keyB64: string): Promise<string> {
+    const key = await crypto.subtle.importKey(
+        'raw',
+        b64ToBytes(keyB64),
+        'AES-GCM',
+        false,
+        ['encrypt']
+    );
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const cipher = await crypto.subtle.encrypt(
+        { name: 'AES-GCM', iv },
+        key,
+        new TextEncoder().encode(value)
+    );
+    const out = new Uint8Array(iv.length + cipher.byteLength);
+    out.set(iv, 0);
+    out.set(new Uint8Array(cipher), iv.length);
+    return bytesToB64(out);
+}
+
+async function decryptField(value: string, keyB64: string): Promise<string> {
+    const data = b64ToBytes(value);
+    const iv = data.slice(0, 12);
+    const cipher = data.slice(12);
+    const key = await crypto.subtle.importKey(
+        'raw',
+        b64ToBytes(keyB64),
+        'AES-GCM',
+        false,
+        ['decrypt']
+    );
+    const plain = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, cipher);
+    return new TextDecoder().decode(plain);
+}
+
+async function encryptData(data: Data, key: string): Promise<Data> {
+    const result: Data = structuredClone(data);
+    for (const product of Object.values(result.products || {})) {
+        for (const field of ['username', 'password', 'secret'] as const) {
+            const value = product[field];
+            if (typeof value === 'string') {
+                product[field] = await encryptField(value, key);
+            }
+        }
+    }
+    return result;
+}
+
+async function decryptData(data: Data, key: string): Promise<Data> {
+    const result: Data = structuredClone(data);
+    for (const product of Object.values(result.products || {})) {
+        for (const field of ['username', 'password', 'secret'] as const) {
+            const value = product[field];
+            if (typeof value === 'string') {
+                try {
+                    product[field] = await decryptField(value, key);
+                } catch {
+                    product[field] = '';
+                }
+            }
+        }
+    }
+    return result;
+}
+
+async function loadData(env: Env): Promise<Data> {
+    const stored = await env.DATA.get('state', 'json');
+    if (stored) {
+        return decryptData(stored as Data, env.FERNET_KEY);
+    }
+    return { products: {}, pending: [], languages: {} };
+}
+
+async function saveData(env: Env, data: Data): Promise<void> {
+    const encrypted = await encryptData(data, env.FERNET_KEY);
+    await env.DATA.put('state', JSON.stringify(encrypted));
 }
 
 export default {
         async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
                 const url = new URL(request.url);
                 switch (url.pathname) {
+                        case '/data':
+                                if (request.method === 'GET') {
+                                        const data = await loadData(env);
+                                        return new Response(JSON.stringify(data), {
+                                                headers: { 'content-type': 'application/json' },
+                                        });
+                                } else if (request.method === 'POST') {
+                                        const payload: Data = await request.json();
+                                        await saveData(env, payload);
+                                        return new Response('OK');
+                                }
+                                return new Response('Method Not Allowed', { status: 405 });
                         case '/message':
                                 return new Response(`Hello, ${env.ADMIN_ID}!`);
-			case '/random':
-				return new Response(crypto.randomUUID());
-			default:
+                        case '/random':
+                                return new Response(crypto.randomUUID());
+                        default:
 				return new Response('Not Found', { status: 404 });
 		}
 	},

--- a/worker/my-worker/wrangler.toml
+++ b/worker/my-worker/wrangler.toml
@@ -7,3 +7,8 @@ route = "https://example.com/*"
 
 [build]
 command = "npm run build"
+
+[[kv_namespaces]]
+binding = "DATA"
+id = "00000000000000000000000000000000"
+preview_id = "00000000000000000000000000000000"


### PR DESCRIPTION
## Summary
- configure Wrangler to use a KV namespace
- implement Worker-side KV storage with crypto.subtle encryption
- add a WorkerStorage backend for the Telegram bot
- use WorkerStorage in `bot.py`

## Testing
- `flake8` *(fails: many style errors)*
- `pytest -q` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_687413789384832d862b7f98b220be75