### PR TITLE
Add TypeScript translations helper

### DIFF
--- a/worker/my-worker/src/translations.ts
+++ b/worker/my-worker/src/translations.ts
@@ -1,0 +1,436 @@
+export const TRANSLATIONS = {
+  "welcome": {
+    "en": "Welcome! Use /products to list products.",
+    "fa": "به بات خوش آمدید! برای مشاهده محصولات از /products استفاده کنید."
+  },
+  "menu_products": {
+    "en": "Products",
+    "fa": "محصولات"
+  },
+  "menu_contact": {
+    "en": "Contact",
+    "fa": "تماس"
+  },
+  "menu_help": {
+    "en": "Help",
+    "fa": "راهنما"
+  },
+  "menu_pending": {
+    "en": "Pending",
+    "fa": "در انتظار"
+  },
+  "menu_admin": {
+    "en": "Admin",
+    "fa": "مدیریت"
+  },
+  "menu_main": {
+    "en": "Main menu",
+    "fa": "منوی اصلی"
+  },
+  "menu_back": {
+    "en": "Back",
+    "fa": "بازگشت"
+  },
+  "back_button": {
+    "en": "Back",
+    "fa": "بازگشت"
+  },
+  "menu_addproduct": {
+    "en": "Add product",
+    "fa": "افزودن محصول"
+  },
+  "menu_editproduct": {
+    "en": "Edit product",
+    "fa": "ویرایش محصول"
+  },
+  "menu_deleteproduct": {
+    "en": "Delete product",
+    "fa": "حذف محصول"
+  },
+  "menu_manage_products": {
+    "en": "Manage products",
+    "fa": "مدیریت محصولات"
+  },
+  "menu_stats": {
+    "en": "Stats",
+    "fa": "آمار"
+  },
+  "menu_buyers": {
+    "en": "Buyers",
+    "fa": "خریداران"
+  },
+  "menu_clearbuyers": {
+    "en": "Clear buyers",
+    "fa": "پاک‌سازی خریداران"
+  },
+  "menu_resend": {
+    "en": "Resend credentials",
+    "fa": "ارسال مجدد اطلاعات"
+  },
+  "admin_phone": {
+    "en": "Admin phone: {phone}",
+    "fa": "شماره مدیر: {phone}"
+  },
+  "ask_product_id": {
+    "en": "Enter product ID:",
+    "fa": "شناسه محصول را وارد کنید:"
+  },
+  "ask_product_price": {
+    "en": "Enter price:",
+    "fa": "قیمت را وارد کنید:"
+  },
+  "ask_product_username": {
+    "en": "Enter username:",
+    "fa": "نام کاربری را وارد کنید:"
+  },
+  "ask_product_password": {
+    "en": "Enter password:",
+    "fa": "رمز عبور را وارد کنید:"
+  },
+  "ask_product_secret": {
+    "en": "Enter TOTP secret:",
+    "fa": "رمز TOTP را وارد کنید:"
+  },
+  "ask_product_name": {
+    "en": "Enter product name:",
+    "fa": "نام محصول را وارد کنید:"
+  },
+  "ask_new_value": {
+    "en": "Enter new value:",
+    "fa": "مقدار جدید را وارد کنید:"
+  },
+  "cancel_button": {
+    "en": "Cancel",
+    "fa": "لغو"
+  },
+  "buy_button": {
+    "en": "Buy",
+    "fa": "خرید"
+  },
+  "no_products": {
+    "en": "No products available",
+    "fa": "محصولی موجود نیست"
+  },
+  "send_proof": {
+    "en": "Send payment proof as a photo to proceed.",
+    "fa": "برای ادامه، رسید پرداخت را به صورت عکس ارسال کنید."
+  },
+  "payment_submitted": {
+    "en": "Payment submitted. Wait for admin approval.",
+    "fa": "پرداخت ثبت شد. منتظر تایید مدیر باشید."
+  },
+  "approve_usage": {
+    "en": "Usage: /approve <user_id> <product_id>",
+    "fa": "استفاده: /approve <user_id> <product_id>"
+  },
+  "approved": {
+    "en": "Approved.",
+    "fa": "تایید شد."
+  },
+  "unauthorized": {
+    "en": "Unauthorized",
+    "fa": "اجازه دسترسی ندارید"
+  },
+  "pending_not_found": {
+    "en": "Pending purchase not found.",
+    "fa": "خرید در انتظار یافت نشد."
+  },
+  "no_pending": {
+    "en": "No pending purchases",
+    "fa": "خرید در انتظاری وجود ندارد"
+  },
+  "pending_entry": {
+    "en": "User {user_id} waiting for {product_id}",
+    "fa": "کاربر {user_id} منتظر {product_id}"
+  },
+  "reject_usage": {
+    "en": "Usage: /reject <user_id> <product_id>",
+    "fa": "استفاده: /reject <user_id> <product_id>"
+  },
+  "rejected": {
+    "en": "Purchase rejected.",
+    "fa": "خرید رد شد."
+  },
+  "operation_cancelled": {
+    "en": "Operation cancelled.",
+    "fa": "عملیات لغو شد."
+  },
+  "approve_button": {
+    "en": "Approve",
+    "fa": "تایید"
+  },
+  "reject_button": {
+    "en": "Reject",
+    "fa": "رد"
+  },
+  "delete_button": {
+    "en": "Delete",
+    "fa": "حذف"
+  },
+  "resend_button": {
+    "en": "Resend",
+    "fa": "ارسال مجدد"
+  },
+  "code_usage": {
+    "en": "Usage: /code <product_id>",
+    "fa": "استفاده: /code <product_id>"
+  },
+  "product_not_found": {
+    "en": "Product not found",
+    "fa": "محصول یافت نشد"
+  },
+  "not_purchased": {
+    "en": "You have not purchased this product.",
+    "fa": "شما این محصول را خریداری نکرده اید."
+  },
+  "no_secret": {
+    "en": "No TOTP secret set for this product.",
+    "fa": "رمز TOTP برای این محصول تنظیم نشده است."
+  },
+  "code_msg": {
+    "en": "Code: {code}",
+    "fa": "کد: {code}"
+  },
+  "setlang_usage": {
+    "en": "Usage: /setlang <code>",
+    "fa": "استفاده: /setlang <code>"
+  },
+  "language_set": {
+    "en": "Language updated.",
+    "fa": "زبان به روز شد."
+  },
+  "unsupported_language": {
+    "en": "Unsupported language code.",
+    "fa": "کد زبان پشتیبانی نمی‌شود."
+  },
+  "addproduct_usage": {
+    "en": "Usage: /addproduct <id> <price> <username> <password> <secret> [name]",
+    "fa": "استفاده: /addproduct <id> <price> <username> <password> <secret> [name]"
+  },
+  "product_exists": {
+    "en": "Product already exists",
+    "fa": "محصول از قبل وجود دارد"
+  },
+  "product_added": {
+    "en": "Product added",
+    "fa": "محصول اضافه شد"
+  },
+  "select_product_edit": {
+    "en": "Select a product to edit:",
+    "fa": "محصول مورد نظر برای ویرایش را انتخاب کنید:"
+  },
+  "select_product_stats": {
+    "en": "Select a product to view stats:",
+    "fa": "محصول مورد نظر برای مشاهده آمار را انتخاب کنید:"
+  },
+  "select_product_buyers": {
+    "en": "Select a product to list buyers:",
+    "fa": "محصول مورد نظر برای مشاهده خریداران را انتخاب کنید:"
+  },
+  "select_product_clearbuyers": {
+    "en": "Select a product to clear buyers:",
+    "fa": "محصول مورد نظر برای پاک‌سازی خریداران را انتخاب کنید:"
+  },
+  "select_product_delete": {
+    "en": "Select a product to delete:",
+    "fa": "محصول مورد نظر برای حذف را انتخاب کنید:"
+  },
+  "editproduct_usage": {
+    "en": "Usage: /editproduct <id> <field> <value> (field: price, username, password, secret, name)",
+    "fa": "استفاده: /editproduct <id> <field> <value>"
+  },
+  "select_field_edit": {
+    "en": "Select a field to edit:",
+    "fa": "فیلد مورد نظر برای ویرایش را انتخاب کنید:"
+  },
+  "invalid_field": {
+    "en": "Invalid field",
+    "fa": "فیلد نامعتبر"
+  },
+  "enter_new_value": {
+    "en": "Enter new value:",
+    "fa": "مقدار جدید را وارد کنید:"
+  },
+  "product_updated": {
+    "en": "Product updated",
+    "fa": "محصول به روز شد"
+  },
+  "deleteproduct_usage": {
+    "en": "Usage: /deleteproduct <id>",
+    "fa": "استفاده: /deleteproduct <id>"
+  },
+  "product_deleted": {
+    "en": "Product deleted",
+    "fa": "محصول حذف شد"
+  },
+  "confirm_delete": {
+    "en": "Delete {pid}?",
+    "fa": "حذف {pid}؟"
+  },
+  "resend_usage": {
+    "en": "Usage: /resend <product_id> [user_id]",
+    "fa": "استفاده: /resend <product_id> [user_id]"
+  },
+  "invalid_user_id": {
+    "en": "Invalid user id",
+    "fa": "آی‌دی کاربر نامعتبر"
+  },
+  "no_buyers_send": {
+    "en": "No buyers to send to",
+    "fa": "خریداری برای ارسال وجود ندارد"
+  },
+  "credentials_resent": {
+    "en": "Credentials resent",
+    "fa": "اطلاعات ورود دوباره ارسال شد"
+  },
+  "credentials_msg": {
+    "en": "Username: {username}\nPassword: {password}",
+    "fa": "نام کاربری: {username}\nرمز عبور: {password}"
+  },
+  "use_code_hint": {
+    "en": "Use /code {pid} to get your current authenticator code.",
+    "fa": "برای دریافت کد احراز هویت، از /code {pid} استفاده کنید."
+  },
+  "code_button": {
+    "en": "Get code",
+    "fa": "دریافت کد"
+  },
+  "use_code_button": {
+    "en": "Press the button to get your current authenticator code.",
+    "fa": "برای دریافت کد احراز هویت، دکمه را بزنید."
+  },
+  "stats_usage": {
+    "en": "Usage: /stats <product_id>",
+    "fa": "استفاده: /stats <product_id>"
+  },
+  "price_line": {
+    "en": "Price: {price}",
+    "fa": "قیمت: {price}"
+  },
+  "total_buyers_line": {
+    "en": "Total buyers: {count}",
+    "fa": "تعداد خریداران: {count}"
+  },
+  "buyers_usage": {
+    "en": "Usage: /buyers <product_id>",
+    "fa": "استفاده: /buyers <product_id>"
+  },
+  "buyers_list": {
+    "en": "Buyers: {list}",
+    "fa": "خریداران: {list}"
+  },
+  "no_buyers": {
+    "en": "No buyers",
+    "fa": "خریداری وجود ندارد"
+  },
+  "deletebuyer_usage": {
+    "en": "Usage: /deletebuyer <product_id> <user_id>",
+    "fa": "استفاده: /deletebuyer <product_id> <user_id>"
+  },
+  "buyer_removed": {
+    "en": "Buyer removed",
+    "fa": "خریدار حذف شد"
+  },
+  "buyer_not_found": {
+    "en": "Buyer not found",
+    "fa": "خریدار یافت نشد"
+  },
+  "clearbuyers_usage": {
+    "en": "Usage: /clearbuyers <product_id>",
+    "fa": "استفاده: /clearbuyers <product_id>"
+  },
+  "all_buyers_removed": {
+    "en": "All buyers removed",
+    "fa": "همه خریداران حذف شدند"
+  },
+  "help_user_header": {
+    "en": "*User commands*",
+    "fa": "*دستورات کاربر*"
+  },
+  "help_admin_header": {
+    "en": "*Admin commands*",
+    "fa": "*دستورات مدیر*"
+  },
+  "help_user_start": {
+    "en": "/start - start the bot",
+    "fa": "/start - شروع ربات"
+  },
+  "help_user_products": {
+    "en": "/products - list available products",
+    "fa": "/products - لیست محصولات موجود"
+  },
+  "help_user_code": {
+    "en": "/code <product_id> - get authenticator code",
+    "fa": "/code <product_id> - دریافت کد احراز هویت"
+  },
+  "help_user_contact": {
+    "en": "/contact - view admin phone number",
+    "fa": "/contact - مشاهده شماره مدیر"
+  },
+  "help_user_setlang": {
+    "en": "/setlang <code> - change your language",
+    "fa": "/setlang <code> - تغییر زبان"
+  },
+  "help_user_help": {
+    "en": "/help - show this message",
+    "fa": "/help - نمایش این پیام"
+  },
+  "help_admin_approve": {
+    "en": "/approve <user_id> <product_id> - approve a pending purchase",
+    "fa": "/approve <user_id> <product_id> - تایید خرید در انتظار"
+  },
+  "help_admin_reject": {
+    "en": "/reject <user_id> <product_id> - reject a pending purchase",
+    "fa": "/reject <user_id> <product_id> - رد خرید در انتظار"
+  },
+  "help_admin_pending": {
+    "en": "/pending - list pending purchases",
+    "fa": "/pending - لیست خریدهای در انتظار"
+  },
+  "help_admin_addproduct": {
+    "en": "/addproduct <id> <price> <username> <password> <secret> [name] - add a product",
+    "fa": "/addproduct <id> <price> <username> <password> <secret> [name] - افزودن محصول"
+  },
+  "help_admin_editproduct": {
+    "en": "/editproduct <id> <field> <value> - edit product info (price, username, password, secret, name)",
+    "fa": "/editproduct <id> <field> <value> - ویرایش مشخصات محصول"
+  },
+  "help_admin_buyers": {
+    "en": "/buyers <product_id> - list buyers of a product",
+    "fa": "/buyers <product_id> - لیست خریداران محصول"
+  },
+  "help_admin_deletebuyer": {
+    "en": "/deletebuyer <product_id> <user_id> - remove a buyer",
+    "fa": "/deletebuyer <product_id> <user_id> - حذف یک خریدار"
+  },
+  "help_admin_clearbuyers": {
+    "en": "/clearbuyers <product_id> - remove all buyers",
+    "fa": "/clearbuyers <product_id> - حذف همه خریداران"
+  },
+  "help_admin_resend": {
+    "en": "/resend <product_id> [user_id] - resend credentials",
+    "fa": "/resend <product_id> [user_id] - ارسال دوباره اطلاعات"
+  },
+  "help_admin_stats": {
+    "en": "/stats <product_id> - show product statistics",
+    "fa": "/stats <product_id> - نمایش آمار محصول"
+  },
+  "menu_language": {
+    "en": "Language",
+    "fa": "زبان"
+  },
+  "lang_en": {
+    "en": "English",
+    "fa": "انگلیسی"
+  },
+  "lang_fa": {
+    "en": "Farsi",
+    "fa": "فارسی"
+  }
+} as const;
+
+export type Lang = "en" | "fa";
+
+export function tr(key: keyof typeof TRANSLATIONS, lang: Lang = "en"): string {
+  return TRANSLATIONS[key]?.[lang] ?? key;
+}


### PR DESCRIPTION
## Summary
- port translation constants to TypeScript
- implement `tr()` for looking up translations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687418c7400c832dae78b4ba7256cd38