### PR TITLE
Ensure worker encrypts product data

### DIFF
--- a/worker/my-worker/src/index.ts
+++ b/worker/my-worker/src/index.ts
@@ -97,7 +97,7 @@ async function decryptData(data: Data, key: string): Promise<Data> {
 async function loadData(env: Env): Promise<Data> {
     const stored = await env.DATA.get('state', 'json');
     if (stored) {
-        return decryptData(stored as Data, env.FERNET_KEY);
+        return await decryptData(stored as Data, env.FERNET_KEY);
     }
     return { products: {}, pending: [], languages: {} };
 }

--- a/worker/my-worker/src/telegram.ts
+++ b/worker/my-worker/src/telegram.ts
@@ -83,7 +83,7 @@ async function decryptData(data: Data, key: string): Promise<Data> {
 async function loadData(env: Env): Promise<Data> {
   const stored = await env.DATA.get('state', 'json');
   if (stored) {
-    return decryptData(stored as Data, env.FERNET_KEY);
+    return await decryptData(stored as Data, env.FERNET_KEY);
   }
   return { products: {}, pending: [], languages: {} };
 }

--- a/worker/my-worker/test/storage.spec.ts
+++ b/worker/my-worker/test/storage.spec.ts
@@ -1,0 +1,40 @@
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
+import { describe, it, expect } from 'vitest';
+import worker from '../src';
+
+// Provide a fixed key for crypto operations
+env.FERNET_KEY = 'MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=';
+
+const sampleData = {
+  products: {
+    p1: { price: '1', username: 'user', password: 'pass', secret: 'sec', buyers: [] },
+  },
+  pending: [],
+  languages: {},
+};
+
+describe('data encryption', () => {
+  it('encrypts and decrypts product fields', async () => {
+    const post = new Request('http://example.com/data', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(sampleData),
+    });
+    const ctx = createExecutionContext();
+    await worker.fetch(post, env, ctx);
+    await waitOnExecutionContext(ctx);
+
+    const stored = await env.DATA.get('state', 'json');
+    const storedProduct = stored.products.p1;
+    expect(storedProduct.username).not.toBe('user');
+    expect(storedProduct.password).not.toBe('pass');
+    expect(storedProduct.secret).not.toBe('sec');
+
+    const getReq = new Request('http://example.com/data');
+    const ctx2 = createExecutionContext();
+    const resp = await worker.fetch(getReq, env, ctx2);
+    await waitOnExecutionContext(ctx2);
+    const loaded = await resp.json();
+    expect(loaded).toEqual(sampleData);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure decryptData is awaited when loading state
- add matching fix in telegram module
- test that product credentials roundtrip via the `/data` endpoint

## Testing
- `npx vitest run`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687426c742fc832db5a33fd612f1b38f