### PR TITLE
Add language update support to worker

### DIFF
--- a/worker/my-worker/test/setlang.spec.ts
+++ b/worker/my-worker/test/setlang.spec.ts
@@ -1,0 +1,71 @@
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import worker from '../src';
+
+env.FERNET_KEY = 'MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=';
+env.ADMIN_ID = '1';
+env.BOT_TOKEN = 'TEST';
+
+const TELEGRAM_URL = `https://api.telegram.org/bot${env.BOT_TOKEN}/sendMessage`;
+
+describe('setlang command', () => {
+  const mockFetch = vi.fn(async () => new Response('sent'));
+
+  beforeEach(async () => {
+    vi.stubGlobal('fetch', mockFetch);
+    await env.DATA.delete('state');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockFetch.mockClear();
+  });
+
+  it('updates language in KV', async () => {
+    const update = { message: { chat: { id: 2 }, text: '/setlang fa' } };
+    const req = new Request('http://example.com/telegram', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(update),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(await res.text()).toBe('OK');
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.text).toBe('زبان به روز شد.');
+
+    const dataReq = new Request('http://example.com/data');
+    const ctx2 = createExecutionContext();
+    const resp = await worker.fetch(dataReq, env, ctx2);
+    await waitOnExecutionContext(ctx2);
+    const data = await resp.json();
+    expect(data.languages['2']).toBe('fa');
+  });
+
+  it('rejects invalid language', async () => {
+    const update = { message: { chat: { id: 2 }, text: '/setlang zz' } };
+    const req = new Request('http://example.com/telegram', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(update),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(await res.text()).toBe('OK');
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.text).toBe('Unsupported language code.');
+
+    const dataReq = new Request('http://example.com/data');
+    const ctx2 = createExecutionContext();
+    const resp = await worker.fetch(dataReq, env, ctx2);
+    await waitOnExecutionContext(ctx2);
+    const data = await resp.json();
+    expect(data.languages).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- sync worker language tracking with main bot
- implement `/setlang` command and language callback menu
- add tests for new worker language logic

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68742c7b6230832dbc8940df07833b91