### PR TITLE
Document required Node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,13 +184,21 @@ flake8
 pytest
 ```
 
+When working on the Cloudflare Worker, use Node.js 20 or later so `wrangler`
+can start the development server without errors.
+
 The unit tests require `python-telegram-bot`. Tests depending on it are skipped
 automatically when the package is missing so the suite can run without the
 dependency.
 ## Worker Deployment
 
 This project includes a Cloudflare Worker located in `worker/my-worker` that can
-serve the bot without running a dedicated server. To deploy the Worker:
+serve the bot without running a dedicated server.
+
+**Prerequisite:** ensure you have Node.js version 20 or newer installed. Older
+versions may fail to start the Worker.
+
+To deploy the Worker:
 
 1. Install [Wrangler](https://developers.cloudflare.com/workers/wrangler/) and
    ensure you are logged in (`wrangler login`).

--- a/worker/my-worker/package.json
+++ b/worker/my-worker/package.json
@@ -16,8 +16,11 @@
 		"vitest": "~3.2.0",
 		"wrangler": "^4.24.3"
 	},
-	"dependencies": {
-		"fernet": "^0.3.3",
-		"otplib": "^12.0.1"
-	}
+  "dependencies": {
+    "fernet": "^0.3.3",
+    "otplib": "^12.0.1"
+  },
+  "engines": {
+    "node": ">=20"
+  }
 }


### PR DESCRIPTION
## Summary
- require Node 20+ for the Worker
- mention the Node requirement in the development and deployment docs

## Testing
- `PYTHONPATH=. pytest -q`
- `flake8` *(fails: F401, E501 etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687438292168832d93d9e9c70f15f085