### PR TITLE
Translate Python workflow to TypeScript

### DIFF
--- a/worker/my-worker/src/telegram.ts
+++ b/worker/my-worker/src/telegram.ts
@@ -1,6 +1,7 @@
 import type { Env } from './env';
 import { tr, type Lang } from './translations';
 import { type Data, encryptData, decryptData } from './crypto';
+import { authenticator } from 'otplib';
 
 async function loadData(env: Env): Promise<Data> {
   const stored = await env.DATA.get('state', 'json');
@@ -103,6 +104,20 @@ export function buildAdminMenu(lang: Lang): InlineKeyboardMarkup {
     [{ text: tr('menu_manage_products', lang), callback_data: 'adminmenu:manage' }],
     [{ text: tr('menu_stats', lang), callback_data: 'adminmenu:stats' }],
     [{ text: tr('menu_back', lang), callback_data: 'menu:main' }],
+  ];
+  return { inline_keyboard: rows };
+}
+
+export function buildProductsMenu(lang: Lang): InlineKeyboardMarkup {
+  const rows: InlineKeyboardButton[][] = [
+    [{ text: tr('menu_addproduct', lang), callback_data: 'adminmenu:addproduct' }],
+    [{ text: tr('menu_editproduct', lang), callback_data: 'adminmenu:editproduct' }],
+    [{ text: tr('menu_deleteproduct', lang), callback_data: 'adminmenu:deleteproduct' }],
+    [{ text: tr('menu_stats', lang), callback_data: 'adminmenu:stats' }],
+    [{ text: tr('menu_buyers', lang), callback_data: 'adminmenu:buyers' }],
+    [{ text: tr('menu_clearbuyers', lang), callback_data: 'adminmenu:clearbuyers' }],
+    [{ text: tr('menu_resend', lang), callback_data: 'adminmenu:resend' }],
+    [{ text: tr('menu_back', lang), callback_data: 'menu:admin' }],
   ];
   return { inline_keyboard: rows };
 }
@@ -249,12 +264,267 @@ export async function handleSetLang(update: TelegramUpdate, env: Env): Promise<v
   await sendMessage(env, chatId, tr('language_set', code as Lang));
 }
 
+export async function handleApprove(update: TelegramUpdate, env: Env): Promise<void> {
+  const chatId = update.message?.chat.id;
+  if (!chatId) return;
+  const lang = await userLang(env, chatId);
+  if (!isAdmin(env, chatId)) {
+    await sendMessage(env, chatId, tr('unauthorized', lang));
+    return;
+  }
+  const args = (update.message?.text || '').split(/\s+/).slice(1);
+  const userId = Number(args[0]);
+  const pid = args[1];
+  if (!userId || !pid) {
+    await sendMessage(env, chatId, tr('approve_usage', lang));
+    return;
+  }
+  const data = await loadData(env);
+  const index = data.pending.findIndex(p => p.user_id === userId && p.product_id === pid);
+  if (index === -1) {
+    await sendMessage(env, chatId, tr('pending_not_found', lang));
+    return;
+  }
+  data.pending.splice(index, 1);
+  const product = data.products[pid];
+  if (!product) {
+    await sendMessage(env, chatId, tr('product_not_found', lang));
+    return;
+  }
+  const buyers = product.buyers || [];
+  if (!buyers.includes(userId)) buyers.push(userId);
+  product.buyers = buyers;
+  await saveData(env, data);
+  const msg = tr('credentials_msg', lang)
+    .replace('{username}', product.username)
+    .replace('{password}', product.password);
+  await sendMessage(env, userId, msg);
+  await sendMessage(env, userId, tr('use_code_button', lang), codeKeyboard(pid, lang));
+  await sendMessage(env, chatId, tr('approved', lang));
+}
+
+export async function handleReject(update: TelegramUpdate, env: Env): Promise<void> {
+  const chatId = update.message?.chat.id;
+  if (!chatId) return;
+  const lang = await userLang(env, chatId);
+  if (!isAdmin(env, chatId)) {
+    await sendMessage(env, chatId, tr('unauthorized', lang));
+    return;
+  }
+  const args = (update.message?.text || '').split(/\s+/).slice(1);
+  const userId = Number(args[0]);
+  const pid = args[1];
+  if (!userId || !pid) {
+    await sendMessage(env, chatId, tr('reject_usage', lang));
+    return;
+  }
+  const data = await loadData(env);
+  const index = data.pending.findIndex(p => p.user_id === userId && p.product_id === pid);
+  if (index === -1) {
+    await sendMessage(env, chatId, tr('pending_not_found', lang));
+    return;
+  }
+  data.pending.splice(index, 1);
+  await saveData(env, data);
+  await sendMessage(env, chatId, tr('rejected', lang));
+}
+
+export async function handleCode(update: TelegramUpdate, env: Env): Promise<void> {
+  const chatId = update.message?.chat.id;
+  if (!chatId) return;
+  const lang = await userLang(env, chatId);
+  const pid = (update.message?.text || '').split(/\s+/)[1];
+  if (!pid) {
+    await sendMessage(env, chatId, tr('code_usage', lang));
+    return;
+  }
+  const data = await loadData(env);
+  const product = data.products[pid];
+  if (!product) {
+    await sendMessage(env, chatId, tr('product_not_found', lang));
+    return;
+  }
+  if (!(product.buyers || []).includes(chatId)) {
+    await sendMessage(env, chatId, tr('not_purchased', lang));
+    return;
+  }
+  const secret = product.secret;
+  if (!secret) {
+    await sendMessage(env, chatId, tr('no_secret', lang));
+    return;
+  }
+  const code = authenticator.generate(secret);
+  await sendMessage(env, chatId, tr('code_msg', lang).replace('{code}', code));
+}
+
+export async function handleEditProduct(update: TelegramUpdate, env: Env): Promise<void> {
+  const chatId = update.message?.chat.id;
+  if (!chatId) return;
+  const lang = await userLang(env, chatId);
+  if (!isAdmin(env, chatId)) {
+    await sendMessage(env, chatId, tr('unauthorized', lang));
+    return;
+  }
+  const args = (update.message?.text || '').split(/\s+/).slice(1);
+  const pid = args[0];
+  const field = args[1] as string;
+  const value = args.slice(2).join(' ');
+  if (!pid || !field || !value) {
+    await sendMessage(env, chatId, tr('editproduct_usage', lang));
+    return;
+  }
+  const data = await loadData(env);
+  const product = data.products[pid];
+  if (!product) {
+    await sendMessage(env, chatId, tr('product_not_found', lang));
+    return;
+  }
+  if (!['price', 'username', 'password', 'secret', 'name'].includes(field)) {
+    await sendMessage(env, chatId, tr('invalid_field', lang));
+    return;
+  }
+  product[field] = value;
+  await saveData(env, data);
+  await sendMessage(env, chatId, tr('product_updated', lang));
+}
+
+export async function handleDeleteProduct(update: TelegramUpdate, env: Env): Promise<void> {
+  const chatId = update.message?.chat.id;
+  if (!chatId) return;
+  const lang = await userLang(env, chatId);
+  if (!isAdmin(env, chatId)) {
+    await sendMessage(env, chatId, tr('unauthorized', lang));
+    return;
+  }
+  const pid = (update.message?.text || '').split(/\s+/)[1];
+  if (!pid) {
+    await sendMessage(env, chatId, tr('deleteproduct_usage', lang));
+    return;
+  }
+  const data = await loadData(env);
+  if (pid in data.products) {
+    delete data.products[pid];
+    await saveData(env, data);
+    await sendMessage(env, chatId, tr('product_deleted', lang));
+  } else {
+    await sendMessage(env, chatId, tr('product_not_found', lang));
+  }
+}
+
+export async function handleDeleteBuyer(update: TelegramUpdate, env: Env): Promise<void> {
+  const chatId = update.message?.chat.id;
+  if (!chatId) return;
+  const lang = await userLang(env, chatId);
+  if (!isAdmin(env, chatId)) {
+    await sendMessage(env, chatId, tr('unauthorized', lang));
+    return;
+  }
+  const args = (update.message?.text || '').split(/\s+/).slice(1);
+  const pid = args[0];
+  const uid = Number(args[1]);
+  if (!pid || !uid) {
+    await sendMessage(env, chatId, tr('deletebuyer_usage', lang));
+    return;
+  }
+  const data = await loadData(env);
+  const product = data.products[pid];
+  if (!product) {
+    await sendMessage(env, chatId, tr('product_not_found', lang));
+    return;
+  }
+  const buyers = product.buyers || [];
+  const index = buyers.indexOf(uid);
+  if (index === -1) {
+    await sendMessage(env, chatId, tr('buyer_not_found', lang));
+    return;
+  }
+  buyers.splice(index, 1);
+  product.buyers = buyers;
+  await saveData(env, data);
+  await sendMessage(env, chatId, tr('buyer_removed', lang));
+}
+
+export async function handleClearBuyers(update: TelegramUpdate, env: Env): Promise<void> {
+  const chatId = update.message?.chat.id;
+  if (!chatId) return;
+  const lang = await userLang(env, chatId);
+  if (!isAdmin(env, chatId)) {
+    await sendMessage(env, chatId, tr('unauthorized', lang));
+    return;
+  }
+  const pid = (update.message?.text || '').split(/\s+/)[1];
+  if (!pid) {
+    await sendMessage(env, chatId, tr('clearbuyers_usage', lang));
+    return;
+  }
+  const data = await loadData(env);
+  const product = data.products[pid];
+  if (!product) {
+    await sendMessage(env, chatId, tr('product_not_found', lang));
+    return;
+  }
+  product.buyers = [];
+  await saveData(env, data);
+  await sendMessage(env, chatId, tr('all_buyers_removed', lang));
+}
+
+export async function handleResend(update: TelegramUpdate, env: Env): Promise<void> {
+  const chatId = update.message?.chat.id;
+  if (!chatId) return;
+  const lang = await userLang(env, chatId);
+  if (!isAdmin(env, chatId)) {
+    await sendMessage(env, chatId, tr('unauthorized', lang));
+    return;
+  }
+  const args = (update.message?.text || '').split(/\s+/).slice(1);
+  const pid = args[0];
+  if (!pid) {
+    await sendMessage(env, chatId, tr('resend_usage', lang));
+    return;
+  }
+  const data = await loadData(env);
+  const product = data.products[pid];
+  if (!product) {
+    await sendMessage(env, chatId, tr('product_not_found', lang));
+    return;
+  }
+  let buyers = product.buyers || [];
+  if (args.length > 1) {
+    const uid = Number(args[1]);
+    if (Number.isNaN(uid)) {
+      await sendMessage(env, chatId, tr('invalid_user_id', lang));
+      return;
+    }
+    buyers = buyers.includes(uid) ? [uid] : [];
+  }
+  if (!buyers.length) {
+    await sendMessage(env, chatId, tr('no_buyers_send', lang));
+    return;
+  }
+  const msg = tr('credentials_msg', lang)
+    .replace('{username}', product.username)
+    .replace('{password}', product.password);
+  for (const uid of buyers) {
+    await sendMessage(env, uid, msg);
+    await sendMessage(env, uid, tr('use_code_button', lang), codeKeyboard(pid, lang));
+  }
+  await sendMessage(env, chatId, tr('credentials_resent', lang));
+}
+
 export const commandHandlers: Record<string, CommandHandler> = {
   '/start': handleStart,
   '/addproduct': handleAddProduct,
   '/pending': handlePending,
   '/stats': handleStats,
   '/buyers': handleBuyers,
+  '/approve': handleApprove,
+  '/reject': handleReject,
+  '/code': handleCode,
+  '/editproduct': handleEditProduct,
+  '/deleteproduct': handleDeleteProduct,
+  '/deletebuyer': handleDeleteBuyer,
+  '/clearbuyers': handleClearBuyers,
+  '/resend': handleResend,
   '/setlang': handleSetLang,
 };
 
@@ -273,22 +543,116 @@ export async function menuCallback(update: TelegramUpdate, env: Env): Promise<vo
     ];
     await sendMessage(env, chatId, tr('menu_language', lang), { inline_keyboard: buttons });
     return;
+    return;
   }
-  await sendMessage(env, chatId, tr('menu_callback_stub', lang));
+  switch (action) {
+    case 'main':
+      await sendMessage(
+        env,
+        chatId,
+        tr('welcome', lang),
+        buildMainMenu(lang, isAdmin(env, chatId)),
+      );
+      break;
+    case 'products': {
+      const data = await loadData(env);
+      const products = Object.entries(data.products);
+      if (!products.length) {
+        await sendMessage(env, chatId, tr('no_products', lang), buildBackMenu(lang));
+        return;
+      }
+      for (const [pid, info] of products) {
+        let text = `${pid}: ${info.price}`;
+        if (info.name) text += `\n${info.name}`;
+        await sendMessage(env, chatId, text, productKeyboard(pid, lang));
+      }
+      await sendMessage(env, chatId, tr('menu_back', lang), buildBackMenu(lang));
+      break;
+    }
+    case 'contact':
+      await sendMessage(
+        env,
+        chatId,
+        tr('admin_phone', lang).replace('{phone}', env.ADMIN_PHONE),
+        buildBackMenu(lang),
+      );
+      break;
+    case 'help': {
+      const userCmds = [
+        tr('help_user_start', lang),
+        tr('help_user_products', lang),
+        tr('help_user_code', lang),
+        tr('help_user_contact', lang),
+        tr('help_user_setlang', lang),
+        tr('help_user_help', lang),
+      ];
+      const adminCmds = [
+        tr('help_admin_approve', lang),
+        tr('help_admin_reject', lang),
+        tr('help_admin_pending', lang),
+        tr('help_admin_addproduct', lang),
+        tr('help_admin_editproduct', lang),
+        tr('help_admin_buyers', lang),
+        tr('help_admin_deletebuyer', lang),
+        tr('help_admin_clearbuyers', lang),
+        tr('help_admin_resend', lang),
+        tr('help_admin_stats', lang),
+      ];
+      const text =
+        tr('help_user_header', lang) + '\n' + userCmds.join('\n') +
+        '\n\n' + tr('help_admin_header', lang) + '\n' + adminCmds.join('\n');
+      await sendMessage(env, chatId, text, buildBackMenu(lang));
+      break;
+    }
+    case 'admin':
+      if (!isAdmin(env, chatId)) {
+        await sendMessage(env, chatId, tr('unauthorized', lang), buildBackMenu(lang));
+        return;
+      }
+      await sendMessage(env, chatId, tr('menu_admin', lang), buildAdminMenu(lang));
+      break;
+  }
 }
 
 export async function buyCallback(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.callback_query?.message?.chat.id;
   if (!chatId) return;
   const lang = await userLang(env, chatId);
-  await sendMessage(env, chatId, tr('buy_callback_stub', lang));
+  const pid = update.callback_query?.data.split(':')[1];
+  if (!pid) return;
+  const data = await loadData(env);
+  if (!data.products[pid]) {
+    await sendMessage(env, chatId, tr('product_not_found', lang));
+    return;
+  }
+  data.pending.push({ user_id: chatId, product_id: pid });
+  await saveData(env, data);
+  await sendMessage(env, chatId, tr('send_proof', lang));
+  await sendMessage(env, Number(env.ADMIN_ID), `/approve ${chatId} ${pid}`);
 }
 
 export async function codeCallback(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.callback_query?.message?.chat.id;
   if (!chatId) return;
   const lang = await userLang(env, chatId);
-  await sendMessage(env, chatId, tr('code_callback_stub', lang));
+  const pid = update.callback_query?.data.split(':')[1];
+  const data = await loadData(env);
+  const product = data.products[pid || ''];
+  if (!product) {
+    await sendMessage(env, chatId, tr('product_not_found', lang));
+    return;
+  }
+  if (!(product.buyers || []).includes(chatId)) {
+    await sendMessage(env, chatId, tr('not_purchased', lang));
+    return;
+  }
+  const secret = product.secret;
+  if (!secret) {
+    await sendMessage(env, chatId, tr('no_secret', lang));
+    return;
+  }
+  const code = authenticator.generate(secret);
+  await sendMessage(env, chatId, tr('code_msg', lang).replace('{code}', code));
 }
 
 export async function languageMenuCallback(update: TelegramUpdate, env: Env): Promise<void> {
@@ -318,63 +682,332 @@ export async function adminMenuCallback(update: TelegramUpdate, env: Env): Promi
   const chatId = update.callback_query?.message?.chat.id;
   if (!chatId) return;
   const lang = await userLang(env, chatId);
-  await sendMessage(env, chatId, tr('admin_menu_callback_stub', lang));
+  if (!isAdmin(env, chatId)) {
+    await sendMessage(env, chatId, tr('unauthorized', lang));
+    return;
+  }
+  const action = update.callback_query?.data.split(':')[1];
+  const data = await loadData(env);
+  switch (action) {
+    case 'pending':
+      if (!data.pending.length) {
+        await sendMessage(env, chatId, tr('no_pending', lang));
+        return;
+      }
+      for (const p of data.pending) {
+        const text = tr('pending_entry', lang)
+          .replace('{user_id}', String(p.user_id))
+          .replace('{product_id}', p.product_id);
+        const buttons = [
+          { text: tr('approve_button', lang), callback_data: `admin:approve:${p.user_id}:${p.product_id}` },
+          { text: tr('reject_button', lang), callback_data: `admin:reject:${p.user_id}:${p.product_id}` },
+        ];
+        await sendMessage(env, chatId, text, { inline_keyboard: [buttons] });
+      }
+      break;
+    case 'manage':
+      await sendMessage(env, chatId, tr('menu_manage_products', lang), buildProductsMenu(lang));
+      break;
+    case 'addproduct':
+      await sendMessage(env, chatId, tr('addproduct_usage', lang), { inline_keyboard: [[{ text: tr('menu_back', lang), callback_data: 'adminmenu:manage' }]] });
+      break;
+    case 'editproduct':
+      if (!Object.keys(data.products).length) {
+        await sendMessage(env, chatId, tr('no_products', lang), { inline_keyboard: [[{ text: tr('menu_back', lang), callback_data: 'adminmenu:manage' }]] });
+        return;
+      }
+      {
+        const buttons = Object.keys(data.products).map(pid => [{ text: pid, callback_data: `editprod:${pid}` }]);
+        buttons.push([{ text: tr('menu_back', lang), callback_data: 'adminmenu:manage' }]);
+        await sendMessage(env, chatId, tr('select_product_edit', lang), { inline_keyboard: buttons });
+      }
+      break;
+    case 'deleteproduct':
+      if (!Object.keys(data.products).length) {
+        await sendMessage(env, chatId, tr('no_products', lang), { inline_keyboard: [[{ text: tr('menu_back', lang), callback_data: 'adminmenu:manage' }]] });
+        return;
+      }
+      {
+        const buttons = Object.keys(data.products).map(pid => [{ text: pid, callback_data: `delprod:${pid}` }]);
+        buttons.push([{ text: tr('menu_back', lang), callback_data: 'adminmenu:manage' }]);
+        await sendMessage(env, chatId, tr('select_product_delete', lang), { inline_keyboard: buttons });
+      }
+      break;
+    case 'buyers':
+      if (!Object.keys(data.products).length) {
+        await sendMessage(env, chatId, tr('no_products', lang), { inline_keyboard: [[{ text: tr('menu_back', lang), callback_data: 'adminmenu:manage' }]] });
+        return;
+      }
+      {
+        const buttons = Object.keys(data.products).map(pid => [{ text: pid, callback_data: `buyerlist:${pid}` }]);
+        buttons.push([{ text: tr('menu_back', lang), callback_data: 'adminmenu:manage' }]);
+        await sendMessage(env, chatId, tr('select_product_buyers', lang), { inline_keyboard: buttons });
+      }
+      break;
+    case 'clearbuyers':
+      if (!Object.keys(data.products).length) {
+        await sendMessage(env, chatId, tr('no_products', lang), { inline_keyboard: [[{ text: tr('menu_back', lang), callback_data: 'adminmenu:manage' }]] });
+        return;
+      }
+      {
+        const buttons = Object.keys(data.products).map(pid => [{ text: pid, callback_data: `adminclearbuyers:${pid}` }]);
+        buttons.push([{ text: tr('menu_back', lang), callback_data: 'adminmenu:manage' }]);
+        await sendMessage(env, chatId, tr('select_product_clearbuyers', lang), { inline_keyboard: buttons });
+      }
+      break;
+    case 'resend':
+      if (!Object.keys(data.products).length) {
+        await sendMessage(env, chatId, tr('no_products', lang), { inline_keyboard: [[{ text: tr('menu_back', lang), callback_data: 'adminmenu:manage' }]] });
+        return;
+      }
+      {
+        const buttons = Object.keys(data.products).map(pid => [{ text: pid, callback_data: `adminresend:${pid}` }]);
+        buttons.push([{ text: tr('menu_back', lang), callback_data: 'adminmenu:manage' }]);
+        await sendMessage(env, chatId, tr('select_product_clearbuyers', lang), { inline_keyboard: buttons });
+      }
+      break;
+    case 'stats':
+      if (!Object.keys(data.products).length) {
+        await sendMessage(env, chatId, tr('no_products', lang), { inline_keyboard: [[{ text: tr('menu_back', lang), callback_data: 'adminmenu:manage' }]] });
+        return;
+      }
+      {
+        const buttons = Object.keys(data.products).map(pid => [{ text: pid, callback_data: `adminstats:${pid}` }]);
+        buttons.push([{ text: tr('menu_back', lang), callback_data: 'adminmenu:manage' }]);
+        await sendMessage(env, chatId, tr('select_product_stats', lang), { inline_keyboard: buttons });
+      }
+      break;
+  }
 }
 
 export async function adminCallback(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.callback_query?.message?.chat.id;
   if (!chatId) return;
   const lang = await userLang(env, chatId);
-  await sendMessage(env, chatId, tr('admin_callback_stub', lang));
+  if (!isAdmin(env, chatId)) {
+    await sendMessage(env, chatId, tr('unauthorized', lang));
+    return;
+  }
+  const parts = update.callback_query?.data.split(':') || [];
+  const action = parts[1];
+  const data = await loadData(env);
+  if (action === 'approve' || action === 'reject') {
+    const userId = Number(parts[2]);
+    const pid = parts[3];
+    if (!userId || !pid) return;
+    const index = data.pending.findIndex(p => p.user_id === userId && p.product_id === pid);
+    if (index === -1) {
+      await sendMessage(env, chatId, tr('pending_not_found', lang));
+      return;
+    }
+    data.pending.splice(index, 1);
+    if (action === 'approve') {
+      const product = data.products[pid];
+      const buyers = product.buyers || [];
+      if (!buyers.includes(userId)) buyers.push(userId);
+      product.buyers = buyers;
+      await saveData(env, data);
+      const msg = tr('credentials_msg', lang)
+        .replace('{username}', product.username)
+        .replace('{password}', product.password);
+      await sendMessage(env, userId, msg);
+      await sendMessage(env, userId, tr('use_code_button', lang), codeKeyboard(pid, lang));
+      await sendMessage(env, chatId, tr('approved', lang));
+    } else {
+      await saveData(env, data);
+      await sendMessage(env, chatId, tr('rejected', lang));
+    }
+    return;
+  } else if (action === 'deletebuyer') {
+    const pid = parts[2];
+    const uid = Number(parts[3]);
+    if (!pid || !uid) return;
+    const product = data.products[pid];
+    if (!product) {
+      await sendMessage(env, chatId, tr('product_not_found', lang));
+      return;
+    }
+    const idx = (product.buyers || []).indexOf(uid);
+    if (idx !== -1) {
+      product.buyers.splice(idx, 1);
+      await saveData(env, data);
+      await sendMessage(env, chatId, tr('buyer_removed', lang));
+    } else {
+      await sendMessage(env, chatId, tr('buyer_not_found', lang));
+    }
+  }
 }
 
 export async function editprodCallback(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.callback_query?.message?.chat.id;
   if (!chatId) return;
   const lang = await userLang(env, chatId);
-  await sendMessage(env, chatId, tr('edit_product_callback_stub', lang));
+  if (!isAdmin(env, chatId)) {
+    await sendMessage(env, chatId, tr('unauthorized', lang));
+    return;
+  }
+  const pid = update.callback_query?.data.split(':')[1];
+  const buttons = [
+    [{ text: 'price', callback_data: `editfield:${pid}:price` }],
+    [{ text: 'username', callback_data: `editfield:${pid}:username` }],
+    [{ text: 'password', callback_data: `editfield:${pid}:password` }],
+    [{ text: 'secret', callback_data: `editfield:${pid}:secret` }],
+    [{ text: 'name', callback_data: `editfield:${pid}:name` }],
+  ];
+  await sendMessage(env, chatId, tr('select_field_edit', lang), { inline_keyboard: buttons });
 }
 
 export async function editfieldCallback(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.callback_query?.message?.chat.id;
   if (!chatId) return;
   const lang = await userLang(env, chatId);
-  await sendMessage(env, chatId, tr('edit_field_callback_stub', lang));
+  const parts = update.callback_query?.data.split(':') || [];
+  const pid = parts[1];
+  const field = parts[2];
+  await sendMessage(env, chatId, `/editproduct ${pid} ${field} <value>`);
 }
 
 export async function buyerlistCallback(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.callback_query?.message?.chat.id;
   if (!chatId) return;
   const lang = await userLang(env, chatId);
-  await sendMessage(env, chatId, tr('buyer_list_callback_stub', lang));
+  if (!isAdmin(env, chatId)) {
+    await sendMessage(env, chatId, tr('unauthorized', lang));
+    return;
+  }
+  const pid = update.callback_query?.data.split(':')[1];
+  const data = await loadData(env);
+  const product = data.products[pid || ''];
+  if (!product) {
+    await sendMessage(env, chatId, tr('product_not_found', lang));
+    return;
+  }
+  const buyers = product.buyers || [];
+  if (!buyers.length) {
+    await sendMessage(env, chatId, tr('no_buyers', lang));
+    return;
+  }
+  for (const uid of buyers) {
+    const btn = [{ text: tr('delete_button', lang), callback_data: `admin:deletebuyer:${pid}:${uid}` }];
+    await sendMessage(env, chatId, String(uid), { inline_keyboard: [btn] });
+  }
 }
 
 export async function clearbuyersCallback(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.callback_query?.message?.chat.id;
   if (!chatId) return;
   const lang = await userLang(env, chatId);
-  await sendMessage(env, chatId, tr('clear_buyers_callback_stub', lang));
+  if (!isAdmin(env, chatId)) {
+    await sendMessage(env, chatId, tr('unauthorized', lang));
+    return;
+  }
+  const pid = update.callback_query?.data.split(':')[1];
+  const data = await loadData(env);
+  const product = data.products[pid || ''];
+  if (!product) {
+    await sendMessage(env, chatId, tr('product_not_found', lang));
+    return;
+  }
+  product.buyers = [];
+  await saveData(env, data);
+  await sendMessage(env, chatId, tr('all_buyers_removed', lang));
 }
 
 export async function resendCallback(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.callback_query?.message?.chat.id;
   if (!chatId) return;
   const lang = await userLang(env, chatId);
-  await sendMessage(env, chatId, tr('resend_callback_stub', lang));
+  if (!isAdmin(env, chatId)) {
+    await sendMessage(env, chatId, tr('unauthorized', lang));
+    return;
+  }
+  const parts = update.callback_query?.data.split(':') || [];
+  if (parts.length === 2) {
+    const pid = parts[1];
+    const data = await loadData(env);
+    const product = data.products[pid];
+    if (!product) {
+      await sendMessage(env, chatId, tr('product_not_found', lang));
+      return;
+    }
+    const buyers = product.buyers || [];
+    if (!buyers.length) {
+      await sendMessage(env, chatId, tr('no_buyers', lang));
+      return;
+    }
+    for (const uid of buyers) {
+      const btn = [{ text: tr('resend_button', lang), callback_data: `adminresend:${pid}:${uid}` }];
+      await sendMessage(env, chatId, String(uid), { inline_keyboard: [btn] });
+    }
+    return;
+  }
+  const pid = parts[1];
+  const uid = Number(parts[2]);
+  const data = await loadData(env);
+  const product = data.products[pid];
+  if (!product || !(product.buyers || []).includes(uid)) {
+    await sendMessage(env, chatId, tr('buyer_not_found', lang));
+    return;
+  }
+  const msg = tr('credentials_msg', lang)
+    .replace('{username}', product.username)
+    .replace('{password}', product.password);
+  await sendMessage(env, uid, msg);
+  await sendMessage(env, uid, tr('use_code_button', lang), codeKeyboard(pid, lang));
+  await sendMessage(env, chatId, tr('credentials_resent', lang));
 }
 
 export async function deleteprodCallback(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.callback_query?.message?.chat.id;
   if (!chatId) return;
   const lang = await userLang(env, chatId);
-  await sendMessage(env, chatId, tr('delete_product_callback_stub', lang));
+  if (!isAdmin(env, chatId)) {
+    await sendMessage(env, chatId, tr('unauthorized', lang));
+    return;
+  }
+  const parts = update.callback_query?.data.split(':') || [];
+  const pid = parts[1];
+  const data = await loadData(env);
+  if (parts.length === 2) {
+    if (!data.products[pid]) {
+      await sendMessage(env, chatId, tr('product_not_found', lang));
+      return;
+    }
+    const buttons = [
+      [{ text: tr('delete_button', lang), callback_data: `delprod:${pid}:confirm` }],
+      [{ text: tr('menu_back', lang), callback_data: 'adminmenu:deleteproduct' }],
+    ];
+    await sendMessage(env, chatId, tr('confirm_delete', lang).replace('{pid}', pid), { inline_keyboard: buttons });
+    return;
+  }
+  if (parts[2] === 'confirm') {
+    if (data.products[pid]) {
+      delete data.products[pid];
+      await saveData(env, data);
+      await sendMessage(env, chatId, tr('product_deleted', lang));
+    } else {
+      await sendMessage(env, chatId, tr('product_not_found', lang));
+    }
+  }
 }
 
 export async function statsCallback(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.callback_query?.message?.chat.id;
   if (!chatId) return;
   const lang = await userLang(env, chatId);
-  await sendMessage(env, chatId, tr('stats_callback_stub', lang));
+  const pid = update.callback_query?.data.split(':')[1];
+  const data = await loadData(env);
+  const product = data.products[pid || ''];
+  if (!product) {
+    await sendMessage(env, chatId, tr('product_not_found', lang));
+    return;
+  }
+  const buyers = product.buyers || [];
+  const text = [
+    tr('price_line', lang).replace('{price}', String(product.price)),
+    tr('total_buyers_line', lang).replace('{count}', String(buyers.length)),
+  ].join('\n');
+  await sendMessage(env, chatId, text);
 }
 
 export const callbackHandlers: Record<string, CallbackHandler> = {

--- a/worker/my-worker/src/translations.ts
+++ b/worker/my-worker/src/translations.ts
@@ -415,54 +415,6 @@ export const TRANSLATIONS = {
     "en": "/stats <product_id> - show product statistics",
     "fa": "/stats <product_id> - نمایش آمار محصول"
   },
-  "menu_callback_stub": {
-    "en": "Menu callback stub",
-    "fa": "پاسخ منو (آزمایشی)"
-  },
-  "buy_callback_stub": {
-    "en": "Buy callback stub",
-    "fa": "پاسخ خرید (آزمایشی)"
-  },
-  "code_callback_stub": {
-    "en": "Code callback stub",
-    "fa": "پاسخ کد (آزمایشی)"
-  },
-  "admin_menu_callback_stub": {
-    "en": "Admin menu callback stub",
-    "fa": "پاسخ منوی مدیر (آزمایشی)"
-  },
-  "admin_callback_stub": {
-    "en": "Admin callback stub",
-    "fa": "پاسخ مدیر (آزمایشی)"
-  },
-  "edit_product_callback_stub": {
-    "en": "Edit product callback stub",
-    "fa": "پاسخ ویرایش محصول (آزمایشی)"
-  },
-  "edit_field_callback_stub": {
-    "en": "Edit field callback stub",
-    "fa": "پاسخ ویرایش فیلد (آزمایشی)"
-  },
-  "buyer_list_callback_stub": {
-    "en": "Buyer list callback stub",
-    "fa": "پاسخ لیست خریداران (آزمایشی)"
-  },
-  "clear_buyers_callback_stub": {
-    "en": "Clear buyers callback stub",
-    "fa": "پاسخ پاک‌سازی خریداران (آزمایشی)"
-  },
-  "resend_callback_stub": {
-    "en": "Resend callback stub",
-    "fa": "پاسخ ارسال مجدد (آزمایشی)"
-  },
-  "delete_product_callback_stub": {
-    "en": "Delete product callback stub",
-    "fa": "پاسخ حذف محصول (آزمایشی)"
-  },
-  "stats_callback_stub": {
-    "en": "Stats callback stub",
-    "fa": "پاسخ آمار (آزمایشی)"
-  },
   "menu_language": {
     "en": "Language",
     "fa": "زبان"


### PR DESCRIPTION
## Summary
- port approve/buyer management logic into the Worker
- flesh out menu callbacks and product editing flows
- remove `_stub` translation strings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68743d5bfc58832dbec4b92ade0c9d6b