### PR TITLE
Add CI workflow including Node 20 setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install Worker dependencies
+        working-directory: worker/my-worker
+        run: npm install --silent
+      - name: Run Worker tests
+        working-directory: worker/my-worker
+        run: npm test --silent
+      - name: Run Python tests
+        run: pytest -q


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for Python and Worker tests
- setup Node.js 20 in the workflow

## Testing
- `pytest -q`
- `npm test --silent` *(fails: expected 'menu_callback_stub' to be 'menu_callback_stub')*

------
https://chatgpt.com/codex/tasks/task_e_687441c4bd60832d9920fc9f41cde8af