### PR TITLE
Switch Telegram bot to D1 storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,17 +203,22 @@ To deploy the Worker:
 1. Install [Wrangler](https://developers.cloudflare.com/workers/wrangler/) and
    ensure you are logged in (`wrangler login`).
 2. Edit `worker/my-worker/wrangler.toml` and replace the example `account_id`,
-   `route`, and KV namespace IDs with values from your Cloudflare account.
+   `route`, and resource IDs with values from your Cloudflare account.
 3. Create the KV namespace defined in the `wrangler.toml` file and note its IDs.
-4. From the `worker/my-worker` directory, set the required secrets:
+4. Create the D1 database and apply migrations:
+   ```bash
+   wrangler d1 create account-bot
+   wrangler d1 migrations apply account-bot
+   ```
+5. From the `worker/my-worker` directory, set the required secrets:
    ```bash
    wrangler secret put BOT_TOKEN
    wrangler secret put ADMIN_ID
    wrangler secret put ADMIN_PHONE
    wrangler secret put FERNET_KEY
    ```
-5. Deploy the Worker by running `wrangler deploy` (or `npm run deploy`).
-6. After deployment, set the Telegram webhook to point to the Worker route:
+6. Deploy the Worker by running `wrangler deploy` (or `npm run deploy`).
+7. After deployment, set the Telegram webhook to point to the Worker route:
    ```bash
    curl "https://api.telegram.org/bot<YOUR_TOKEN>/setWebhook?url=https://<YOUR_WORKER_DOMAIN>/telegram"
    ```

--- a/worker/my-worker/migrations/0001_init.sql
+++ b/worker/my-worker/migrations/0001_init.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS products (
+  id TEXT PRIMARY KEY,
+  price TEXT NOT NULL,
+  username TEXT NOT NULL,
+  password TEXT NOT NULL,
+  secret TEXT NOT NULL,
+  name TEXT,
+  buyers TEXT NOT NULL DEFAULT '[]'
+);
+
+CREATE TABLE IF NOT EXISTS pending (
+  user_id INTEGER NOT NULL,
+  product_id TEXT NOT NULL,
+  PRIMARY KEY (user_id, product_id)
+);
+
+CREATE TABLE IF NOT EXISTS languages (
+  user_id INTEGER PRIMARY KEY,
+  lang TEXT NOT NULL
+);

--- a/worker/my-worker/src/env.ts
+++ b/worker/my-worker/src/env.ts
@@ -4,4 +4,5 @@ export interface Env {
   ADMIN_PHONE: string;
   FERNET_KEY: string;
   DATA: KVNamespace;
+  DB: D1Database;
 }

--- a/worker/my-worker/src/telegram.ts
+++ b/worker/my-worker/src/telegram.ts
@@ -1,19 +1,78 @@
 import type { Env } from './env';
 import { tr, type Lang } from './translations';
-import { type Data, encryptData, decryptData } from './crypto';
+import { type Data, encryptField, decryptField } from './crypto';
 import { authenticator } from 'otplib';
 
 async function loadData(env: Env): Promise<Data> {
-  const stored = await env.DATA.get('state', 'json');
-  if (stored) {
-    return await decryptData(stored as Data, env.FERNET_KEY);
+  const data: Data = { products: {}, pending: [], languages: {} };
+
+  const prodRes = await env.DB.prepare('SELECT * FROM products').all();
+  for (const row of prodRes.results as any[]) {
+    const buyers = row.buyers ? JSON.parse(row.buyers) : [];
+    data.products[row.id] = {
+      price: row.price,
+      username: await decryptField(row.username, env.FERNET_KEY),
+      password: await decryptField(row.password, env.FERNET_KEY),
+      secret: await decryptField(row.secret, env.FERNET_KEY),
+      buyers,
+    };
+    if (row.name) data.products[row.id].name = row.name;
   }
-  return { products: {}, pending: [], languages: {} };
+
+  const pendRes = await env.DB.prepare(
+    'SELECT user_id, product_id FROM pending'
+  ).all();
+  data.pending = (pendRes.results as any[]).map((r) => ({
+    user_id: r.user_id,
+    product_id: r.product_id,
+  }));
+
+  const langRes = await env.DB.prepare(
+    'SELECT user_id, lang FROM languages'
+  ).all();
+  for (const row of langRes.results as any[]) {
+    data.languages[String(row.user_id)] = row.lang;
+  }
+
+  return data;
 }
 
 async function saveData(env: Env, data: Data): Promise<void> {
-  const enc = await encryptData(data, env.FERNET_KEY);
-  await env.DATA.put('state', JSON.stringify(enc));
+  const statements = [
+    env.DB.prepare('DELETE FROM products'),
+    env.DB.prepare('DELETE FROM pending'),
+    env.DB.prepare('DELETE FROM languages'),
+  ];
+
+  for (const [id, product] of Object.entries(data.products)) {
+    const encUser = await encryptField(product.username, env.FERNET_KEY);
+    const encPass = await encryptField(product.password, env.FERNET_KEY);
+    const encSecret = await encryptField(product.secret, env.FERNET_KEY);
+    const buyers = JSON.stringify(product.buyers || []);
+    statements.push(
+      env.DB.prepare(
+        'INSERT INTO products (id, price, username, password, secret, name, buyers) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)'
+      ).bind(id, product.price, encUser, encPass, encSecret, product.name ?? null, buyers)
+    );
+  }
+
+  for (const pending of data.pending) {
+    statements.push(
+      env.DB.prepare(
+        'INSERT INTO pending (user_id, product_id) VALUES (?1, ?2)'
+      ).bind(pending.user_id, pending.product_id)
+    );
+  }
+
+  for (const [uid, lang] of Object.entries(data.languages)) {
+    statements.push(
+      env.DB.prepare(
+        'INSERT INTO languages (user_id, lang) VALUES (?1, ?2)'
+      ).bind(Number(uid), lang)
+    );
+  }
+
+  await env.DB.batch(statements);
 }
 
 async function userLang(env: Env, userId: number): Promise<Lang> {

--- a/worker/my-worker/test/setlang.spec.ts
+++ b/worker/my-worker/test/setlang.spec.ts
@@ -13,6 +13,14 @@ describe('setlang command', () => {
 
   beforeEach(async () => {
     vi.stubGlobal('fetch', mockFetch);
+    const stmts = [
+      'CREATE TABLE IF NOT EXISTS products (id TEXT PRIMARY KEY, price TEXT NOT NULL, username TEXT NOT NULL, password TEXT NOT NULL, secret TEXT NOT NULL, name TEXT, buyers TEXT NOT NULL DEFAULT "[]")',
+      'CREATE TABLE IF NOT EXISTS pending (user_id INTEGER NOT NULL, product_id TEXT NOT NULL, PRIMARY KEY (user_id, product_id))',
+      'CREATE TABLE IF NOT EXISTS languages (user_id INTEGER PRIMARY KEY, lang TEXT NOT NULL)'
+    ];
+    for (const stmt of stmts) {
+      await env.DB.exec(stmt);
+    }
     await env.DATA.delete('state');
   });
 

--- a/worker/my-worker/test/telegram.spec.ts
+++ b/worker/my-worker/test/telegram.spec.ts
@@ -14,6 +14,14 @@ describe('POST /telegram', () => {
 
   beforeEach(async () => {
     vi.stubGlobal('fetch', mockFetch);
+    const stmts = [
+      'CREATE TABLE IF NOT EXISTS products (id TEXT PRIMARY KEY, price TEXT NOT NULL, username TEXT NOT NULL, password TEXT NOT NULL, secret TEXT NOT NULL, name TEXT, buyers TEXT NOT NULL DEFAULT "[]")',
+      'CREATE TABLE IF NOT EXISTS pending (user_id INTEGER NOT NULL, product_id TEXT NOT NULL, PRIMARY KEY (user_id, product_id))',
+      'CREATE TABLE IF NOT EXISTS languages (user_id INTEGER PRIMARY KEY, lang TEXT NOT NULL)'
+    ];
+    for (const stmt of stmts) {
+      await env.DB.exec(stmt);
+    }
     await env.DATA.delete('state');
   });
 

--- a/worker/my-worker/wrangler.toml
+++ b/worker/my-worker/wrangler.toml
@@ -12,3 +12,8 @@ command = "npm run build"
 binding = "DATA"
 id = "00000000000000000000000000000000"
 preview_id = "00000000000000000000000000000000"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "account-bot"
+database_id = "00000000-0000-0000-0000-000000000000"


### PR DESCRIPTION
## Summary
- create D1 schema for products, pending purchases and languages
- bind D1 in wrangler
- query D1 instead of KV in telegram.ts
- document the migration to D1 in README
- adjust unit tests to create tables on start

## Testing
- `flake8` *(fails: E501 in many files)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68744b751c4c832d8178709af727e5df