### PR TITLE
Fix welcome message assertion

### DIFF
--- a/worker/my-worker/test/telegram.spec.ts
+++ b/worker/my-worker/test/telegram.spec.ts
@@ -84,7 +84,7 @@ describe('POST /telegram', () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
-    expect(body.text).toBe(tr('welcome'));
+    expect(body.text).toBe(tr('welcome', 'en'));
 
     const dataReq = new Request('http://example.com/data');
     const ctx2 = createExecutionContext();


### PR DESCRIPTION
## Summary
- update welcome message assertion in telegram test
- adjust tests to use D1-backed endpoint

## Testing
- `npm test --prefix worker/my-worker`

------
https://chatgpt.com/codex/tasks/task_e_6874521da82c832d815e65177bf94574