### PR TITLE
Add R2 support for payment proofs

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,20 +213,24 @@ To deploy the Worker:
 2. Edit `worker/my-worker/wrangler.toml` and replace the example `account_id`,
    `route`, and resource IDs with values from your Cloudflare account.
 3. Create the KV namespace defined in the `wrangler.toml` file and note its IDs.
-4. Create the D1 database and apply migrations:
+4. Create the R2 bucket defined in the `wrangler.toml` file:
+   ```bash
+   wrangler r2 bucket create payment-proofs
+   ```
+5. Create the D1 database and apply migrations:
    ```bash
    wrangler d1 create account-bot
    wrangler d1 migrations apply account-bot
    ```
-5. From the `worker/my-worker` directory, set the required secrets:
+6. From the `worker/my-worker` directory, set the required secrets:
    ```bash
    wrangler secret put BOT_TOKEN
    wrangler secret put ADMIN_ID
    wrangler secret put ADMIN_PHONE
    wrangler secret put FERNET_KEY
    ```
-6. Deploy the Worker by running `wrangler deploy` (or `npm run deploy`).
-7. After deployment, set the Telegram webhook to point to the Worker route:
+7. Deploy the Worker by running `wrangler deploy` (or `npm run deploy`).
+8. After deployment, set the Telegram webhook to point to the Worker route:
    ```bash
    curl "https://api.telegram.org/bot<YOUR_TOKEN>/setWebhook?url=https://<YOUR_WORKER_DOMAIN>/telegram"
    ```

--- a/worker/my-worker/src/env.ts
+++ b/worker/my-worker/src/env.ts
@@ -4,4 +4,5 @@ export interface Env {
   ADMIN_PHONE: string;
   FERNET_KEY: string;
   DB: D1Database;
+  PROOFS: R2Bucket;
 }

--- a/worker/my-worker/src/index.ts
+++ b/worker/my-worker/src/index.ts
@@ -12,7 +12,7 @@
  */
 
 import type { Env } from './env';
-import { commandHandlers, handleCallbackQuery, type TelegramUpdate } from './telegram';
+import { commandHandlers, handleCallbackQuery, handlePhoto, type TelegramUpdate } from './telegram';
 import { authenticator } from 'otplib';
 import { type Data, encryptField, decryptField } from './crypto';
 
@@ -123,6 +123,8 @@ export default {
                                         if (handler) {
                                                 await handler(update, env);
                                         }
+                                } else if (update.message?.photo) {
+                                        await handlePhoto(update, env);
                                 } else if (update.callback_query) {
                                         await handleCallbackQuery(update, env);
                                 }

--- a/worker/my-worker/wrangler.toml
+++ b/worker/my-worker/wrangler.toml
@@ -13,3 +13,8 @@ command = "npm run build"
 binding = "DB"
 database_name = "account-bot"
 database_id = "00000000-0000-0000-0000-000000000000"
+
+[[r2_buckets]]
+binding = "PROOFS"
+bucket_name = "payment-proofs"
+preview_bucket_name = "payment-proofs-dev"


### PR DESCRIPTION
## Summary
- bind an R2 bucket in `wrangler.toml`
- add R2 bucket to worker Env
- store payment proof photos in R2 and forward to admin
- document R2 bucket setup in README

## Testing
- `npx wrangler d1 migrations apply account-bot`
- `npm test`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874fea307c0832da59e3b35b2c7aa1f