### PR TITLE
Switch worker encryption key env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,12 +223,14 @@ To deploy the Worker:
    wrangler d1 migrations apply account-bot
    ```
 6. From the `worker/my-worker` directory, set the required secrets:
-   ```bash
-   wrangler secret put BOT_TOKEN
-   wrangler secret put ADMIN_ID
-   wrangler secret put ADMIN_PHONE
-   wrangler secret put FERNET_KEY
-   ```
+  ```bash
+  wrangler secret put BOT_TOKEN
+  wrangler secret put ADMIN_ID
+  wrangler secret put ADMIN_PHONE
+  wrangler secret put AES_KEY
+  ```
+   The Worker still accepts `FERNET_KEY` for compatibility but this variable is
+   deprecated and will be removed in a future release.
 7. Deploy the Worker by running `wrangler deploy` (or `npm run deploy`).
 8. After deployment, set the Telegram webhook to point to the Worker route:
    ```bash
@@ -259,7 +261,8 @@ existing state:
    wrangler secret put BOT_TOKEN
    wrangler secret put ADMIN_ID
    wrangler secret put ADMIN_PHONE
-   wrangler secret put FERNET_KEY
+   wrangler secret put AES_KEY
+   # `FERNET_KEY` is also supported for existing deployments
    ```
 
 3. Finally, point your Telegram webhook to the Worker route (as shown above).

--- a/worker/my-worker/src/env.ts
+++ b/worker/my-worker/src/env.ts
@@ -2,7 +2,12 @@ export interface Env {
   BOT_TOKEN: string;
   ADMIN_ID: string;
   ADMIN_PHONE: string;
-  FERNET_KEY: string;
+  /**
+   * Base64 encoded AES key used for encrypting credentials.
+   * `FERNET_KEY` is still supported for backward compatibility.
+   */
+  AES_KEY: string;
+  FERNET_KEY?: string;
   DB: D1Database;
   PROOFS: R2Bucket;
 }

--- a/worker/my-worker/src/index.ts
+++ b/worker/my-worker/src/index.ts
@@ -25,9 +25,9 @@ async function loadData(env: Env): Promise<Data> {
         const buyers = row.buyers ? JSON.parse(row.buyers) : [];
         data.products[row.id] = {
             price: row.price,
-            username: await decryptField(row.username, env.FERNET_KEY),
-            password: await decryptField(row.password, env.FERNET_KEY),
-            secret: await decryptField(row.secret, env.FERNET_KEY),
+            username: await decryptField(row.username, env.AES_KEY || env.FERNET_KEY),
+            password: await decryptField(row.password, env.AES_KEY || env.FERNET_KEY),
+            secret: await decryptField(row.secret, env.AES_KEY || env.FERNET_KEY),
             buyers,
         };
         if (row.name) data.products[row.id].name = row.name;
@@ -59,9 +59,10 @@ async function saveData(env: Env, data: Data): Promise<void> {
     ];
 
     for (const [id, product] of Object.entries(data.products)) {
-        const encUser = await encryptField(product.username, env.FERNET_KEY);
-        const encPass = await encryptField(product.password, env.FERNET_KEY);
-        const encSecret = await encryptField(product.secret, env.FERNET_KEY);
+        const key = env.AES_KEY || env.FERNET_KEY;
+        const encUser = await encryptField(product.username, key);
+        const encPass = await encryptField(product.password, key);
+        const encSecret = await encryptField(product.secret, key);
         const buyers = JSON.stringify(product.buyers || []);
         statements.push(
             env.DB.prepare(

--- a/worker/my-worker/src/telegram.ts
+++ b/worker/my-worker/src/telegram.ts
@@ -11,9 +11,9 @@ async function loadData(env: Env): Promise<Data> {
     const buyers = row.buyers ? JSON.parse(row.buyers) : [];
     data.products[row.id] = {
       price: row.price,
-      username: await decryptField(row.username, env.FERNET_KEY),
-      password: await decryptField(row.password, env.FERNET_KEY),
-      secret: await decryptField(row.secret, env.FERNET_KEY),
+      username: await decryptField(row.username, env.AES_KEY || env.FERNET_KEY),
+      password: await decryptField(row.password, env.AES_KEY || env.FERNET_KEY),
+      secret: await decryptField(row.secret, env.AES_KEY || env.FERNET_KEY),
       buyers,
     };
     if (row.name) data.products[row.id].name = row.name;
@@ -45,9 +45,10 @@ async function saveData(env: Env, data: Data): Promise<void> {
   ];
 
   for (const [id, product] of Object.entries(data.products)) {
-    const encUser = await encryptField(product.username, env.FERNET_KEY);
-    const encPass = await encryptField(product.password, env.FERNET_KEY);
-    const encSecret = await encryptField(product.secret, env.FERNET_KEY);
+    const key = env.AES_KEY || env.FERNET_KEY;
+    const encUser = await encryptField(product.username, key);
+    const encPass = await encryptField(product.password, key);
+    const encSecret = await encryptField(product.secret, key);
     const buyers = JSON.stringify(product.buyers || []);
     statements.push(
       env.DB.prepare(

--- a/worker/my-worker/test/setlang.spec.ts
+++ b/worker/my-worker/test/setlang.spec.ts
@@ -2,7 +2,7 @@ import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import worker from '../src';
 
-env.FERNET_KEY = 'MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=';
+env.AES_KEY = 'MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=';
 env.ADMIN_ID = '1';
 env.BOT_TOKEN = 'TEST';
 

--- a/worker/my-worker/test/storage.spec.ts
+++ b/worker/my-worker/test/storage.spec.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import worker from '../src';
 
 // Provide a fixed key for crypto operations
-env.FERNET_KEY = 'MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=';
+env.AES_KEY = 'MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=';
 
 const sampleData = {
   products: {

--- a/worker/my-worker/test/telegram.spec.ts
+++ b/worker/my-worker/test/telegram.spec.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import worker from '../src';
 import { tr } from '../src/translations';
 
-env.FERNET_KEY = 'MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=';
+env.AES_KEY = 'MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=';
 env.ADMIN_ID = '1';
 env.BOT_TOKEN = 'TEST';
 


### PR DESCRIPTION
## Summary
- change Worker environment variable to `AES_KEY`
- support old `FERNET_KEY` as a fallback
- update Worker tests for `AES_KEY`
- document the change and provide migration notes

## Testing
- `flake8`
- `pytest -q`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687502d8e458832db208b0f507a79e0b