### PR TITLE
Add worker test setup and new vitest suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,15 @@ wrangler d1 migrations apply
 ```
 
 The migration files reside in `worker/my-worker/migrations/`.
+Run the Worker tests with Wrangler's Vitest integration from the Worker
+directory:
+
+```bash
+cd worker/my-worker
+npx wrangler vitest
+```
+
+The default `npm test` script runs the same command.
 ## Worker Deployment
 
 This project includes a Cloudflare Worker located in `worker/my-worker` that can

--- a/worker/my-worker/test/pending.spec.ts
+++ b/worker/my-worker/test/pending.spec.ts
@@ -1,0 +1,49 @@
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import worker from '../src';
+import { tr } from '../src/translations';
+import { encryptField } from '../src/crypto';
+
+env.AES_KEY = 'MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=';
+env.ADMIN_ID = '1';
+env.BOT_TOKEN = 'TEST';
+
+const TELEGRAM_URL = `https://api.telegram.org/bot${env.BOT_TOKEN}/sendMessage`;
+
+describe('pending command', () => {
+  const mockFetch = vi.fn(async () => new Response('sent'));
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockFetch.mockClear();
+  });
+
+  it('lists pending purchases from the database', async () => {
+    const encUser = await encryptField('u', env.AES_KEY);
+    const encPass = await encryptField('p', env.AES_KEY);
+    const encSecret = await encryptField('s', env.AES_KEY);
+    await env.DB.exec(`INSERT INTO products (id, price, username, password, secret, name, buyers) VALUES ('p1','10','${encUser}','${encPass}','${encSecret}',NULL,'[]')`);
+    await env.DB.exec("INSERT INTO pending (user_id, product_id) VALUES (2, 'p1')");
+
+    const update = { message: { chat: { id: 1 }, text: '/pending' } };
+    const req = new Request('http://example.com/telegram', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(update),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(await res.text()).toBe('OK');
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
+    const expected = tr('pending_entry', 'en').replace('{user_id}', '2').replace('{product_id}', 'p1');
+    expect(body.text).toBe(expected);
+    expect(mockFetch.mock.calls[0][0]).toBe(TELEGRAM_URL);
+  });
+});

--- a/worker/my-worker/test/photo.spec.ts
+++ b/worker/my-worker/test/photo.spec.ts
@@ -1,0 +1,62 @@
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import worker from '../src';
+import { encryptField } from '../src/crypto';
+
+env.AES_KEY = 'MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=';
+env.ADMIN_ID = '1';
+env.BOT_TOKEN = 'TEST';
+
+const SEND_PHOTO_URL = `https://api.telegram.org/bot${env.BOT_TOKEN}/sendPhoto`;
+const SEND_MSG_URL = `https://api.telegram.org/bot${env.BOT_TOKEN}/sendMessage`;
+
+// Stubs responses for Telegram API
+function telegramFetch(url: string): Response {
+  if (url.includes('/getFile')) {
+    return new Response(JSON.stringify({ ok: true, result: { file_path: 'foo.jpg' } }), {
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+  if (url.includes('/file/bot')) {
+    return new Response('filedata');
+  }
+  return new Response('sent');
+}
+
+describe('photo upload flow', () => {
+  const mockFetch = vi.fn(async (input: any) => telegramFetch(typeof input === 'string' ? input : input.url));
+
+  beforeEach(async () => {
+    vi.stubGlobal('fetch', mockFetch);
+    const encUser = await encryptField('u', env.AES_KEY);
+    const encPass = await encryptField('p', env.AES_KEY);
+    const encSecret = await encryptField('s', env.AES_KEY);
+    await env.DB.exec(`INSERT INTO products (id, price, username, password, secret, name, buyers) VALUES ('p1','10','${encUser}','${encPass}','${encSecret}',NULL,'[]')`);
+    await env.DB.exec("INSERT INTO pending (user_id, product_id) VALUES (2, 'p1')");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockFetch.mockClear();
+  });
+
+  it('stores proof image in R2', async () => {
+    const putSpy = vi.spyOn(env.PROOFS, 'put');
+    const update = { message: { chat: { id: 2 }, photo: [{ file_id: 'f1' }] } };
+    const req = new Request('http://example.com/telegram', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(update),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(await res.text()).toBe('OK');
+
+    expect(putSpy).toHaveBeenCalledTimes(1);
+    expect(putSpy.mock.calls[0][0]).toBe('f1');
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+    expect(mockFetch.mock.calls[2][0]).toBe(SEND_PHOTO_URL);
+    expect(mockFetch.mock.calls[3][0]).toBe(SEND_MSG_URL);
+  });
+});

--- a/worker/my-worker/test/setup.ts
+++ b/worker/my-worker/test/setup.ts
@@ -1,0 +1,19 @@
+import { env } from 'cloudflare:test';
+import { beforeEach } from 'vitest';
+
+// Ensure D1 and R2 are cleared between tests
+beforeEach(async () => {
+  const stmts = [
+    'CREATE TABLE IF NOT EXISTS products (id TEXT PRIMARY KEY, price TEXT NOT NULL, username TEXT NOT NULL, password TEXT NOT NULL, secret TEXT NOT NULL, name TEXT, buyers TEXT NOT NULL DEFAULT "[]")',
+    'CREATE TABLE IF NOT EXISTS pending (user_id INTEGER NOT NULL, product_id TEXT NOT NULL, PRIMARY KEY (user_id, product_id))',
+    'CREATE TABLE IF NOT EXISTS languages (user_id INTEGER PRIMARY KEY, lang TEXT NOT NULL)'
+  ];
+  for (const stmt of stmts) {
+    await env.DB.exec(stmt);
+  }
+  await env.DB.exec('DELETE FROM products; DELETE FROM pending; DELETE FROM languages');
+
+  for (const obj of (await env.PROOFS.list()).objects) {
+    await env.PROOFS.delete(obj.key);
+  }
+});

--- a/worker/my-worker/vitest.config.mts
+++ b/worker/my-worker/vitest.config.mts
@@ -1,11 +1,12 @@
 import { defineWorkersConfig } from '@cloudflare/vitest-pool-workers/config';
 
 export default defineWorkersConfig({
-	test: {
-		poolOptions: {
+       test: {
+               setupFiles: ['./test/setup.ts'],
+               poolOptions: {
                        workers: {
-                                wrangler: { configPath: './wrangler.toml' },
-                        },
-		},
-	},
+                               wrangler: { configPath: './wrangler.toml' },
+                       },
+               },
+       },
 });


### PR DESCRIPTION
## Summary
- set up vitest to wipe stub D1 and R2 before each test
- add tests for pending queries and proof uploads
- document how to run worker tests with wrangler

## Testing
- `npx vitest run`
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68750500f030832d8adab5be2fe07b5e