### PR TITLE
Remove leftover KV references

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,17 +222,16 @@ To deploy the Worker:
    ensure you are logged in (`wrangler login`).
 2. Edit `worker/my-worker/wrangler.toml` and replace the example `account_id`,
    `route`, and resource IDs with values from your Cloudflare account.
-3. Create the KV namespace defined in the `wrangler.toml` file and note its IDs.
-4. Create the R2 bucket defined in the `wrangler.toml` file:
+3. Create the R2 bucket defined in the `wrangler.toml` file:
    ```bash
    wrangler r2 bucket create payment-proofs
    ```
-5. Create the D1 database and apply migrations:
+4. Create the D1 database and apply migrations:
    ```bash
    wrangler d1 create account-bot
    wrangler d1 migrations apply account-bot
    ```
-6. From the `worker/my-worker` directory, set the required secrets:
+5. From the `worker/my-worker` directory, set the required secrets:
   ```bash
   wrangler secret put BOT_TOKEN
   wrangler secret put ADMIN_ID
@@ -241,8 +240,8 @@ To deploy the Worker:
   ```
    The Worker still accepts `FERNET_KEY` for compatibility but this variable is
    deprecated and will be removed in a future release.
-7. Deploy the Worker by running `wrangler deploy` (or `npm run deploy`).
-8. After deployment, set the Telegram webhook to point to the Worker route:
+6. Deploy the Worker by running `wrangler deploy` (or `npm run deploy`).
+7. After deployment, set the Telegram webhook to point to the Worker route:
    ```bash
    curl "https://api.telegram.org/bot<YOUR_TOKEN>/setWebhook?url=https://<YOUR_WORKER_DOMAIN>/telegram"
    ```
@@ -256,8 +255,7 @@ If you have been running the bot locally with `bot.py` and want to move to the
 Cloudflare Worker, deploy the Worker as described above and then copy your
 existing state:
 
-1. Upload your local `data.json` to the KV namespace using the Worker's `/data`
-   endpoint:
+1. Upload your local `data.json` to the Worker using the `/data` endpoint:
 
    ```bash
    curl -X POST -H 'Content-Type: application/json' \

--- a/worker/my-worker/test/setlang.spec.ts
+++ b/worker/my-worker/test/setlang.spec.ts
@@ -29,7 +29,7 @@ describe('setlang command', () => {
     mockFetch.mockClear();
   });
 
-  it('updates language in KV', async () => {
+  it('updates language in the database', async () => {
     const update = { message: { chat: { id: 2 }, text: '/setlang fa' } };
     const req = new Request('http://example.com/telegram', {
       method: 'POST',

--- a/worker/my-worker/test/telegram.spec.ts
+++ b/worker/my-worker/test/telegram.spec.ts
@@ -30,7 +30,7 @@ describe('POST /telegram', () => {
     mockFetch.mockClear();
   });
 
-  it('handles /addproduct message and updates KV', async () => {
+  it('handles /addproduct message and updates the database', async () => {
     const update = {
       message: {
         chat: { id: 1 },


### PR DESCRIPTION
## Summary
- update deployment instructions to remove legacy KV storage details
- clarify migration steps for uploading data.json
- rename tests to mention the database

## Testing
- `npx vitest run`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6874479a5bdc832d89ea5252b9fdf6ff