### PR TITLE
Remove public data route

### DIFF
--- a/worker/my-worker/src/index.ts
+++ b/worker/my-worker/src/index.ts
@@ -14,8 +14,6 @@
 import type { Env } from './env';
 import { commandHandlers, handleCallbackQuery, handlePhoto, handlePendingAddMessage, handlePendingEditMessage, type TelegramUpdate } from './telegram';
 import { authenticator } from 'otplib';
-import type { Data } from './crypto';
-import { loadData, saveData } from './data';
 
 
 
@@ -23,18 +21,6 @@ export default {
         async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
                 const url = new URL(request.url);
                 switch (url.pathname) {
-                        case '/data':
-                                if (request.method === 'GET') {
-                                        const data = await loadData(env);
-                                        return new Response(JSON.stringify(data), {
-                                                headers: { 'content-type': 'application/json' },
-                                        });
-                                } else if (request.method === 'POST') {
-                                        const payload: Data = await request.json();
-                                        await saveData(env, payload);
-                                        return new Response('OK');
-                                }
-                                return new Response('Method Not Allowed', { status: 405 });
                         case '/totp':
                                 const secret = url.searchParams.get('secret');
                                 if (!secret) {

--- a/worker/my-worker/test/setlang.spec.ts
+++ b/worker/my-worker/test/setlang.spec.ts
@@ -1,6 +1,7 @@
 import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import worker from '../src';
+import { loadData } from '../src/data';
 
 env.AES_KEY = 'MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=';
 env.ADMIN_ID = '1';
@@ -47,11 +48,7 @@ describe('setlang command', () => {
     const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
     expect(body.text).toBe('زبان به روز شد.');
 
-    const dataReq = new Request('http://example.com/data');
-    const ctx2 = createExecutionContext();
-    const resp = await worker.fetch(dataReq, env, ctx2);
-    await waitOnExecutionContext(ctx2);
-    const data = await resp.json();
+    const data = await loadData(env);
     expect(data.languages['2']).toBe('fa');
   });
 
@@ -71,11 +68,7 @@ describe('setlang command', () => {
     const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
     expect(body.text).toBe('Unsupported language code.');
 
-    const dataReq = new Request('http://example.com/data');
-    const ctx2 = createExecutionContext();
-    const resp = await worker.fetch(dataReq, env, ctx2);
-    await waitOnExecutionContext(ctx2);
-    const data = await resp.json();
+    const data = await loadData(env);
     expect(data.languages).toEqual({});
   });
 });

--- a/worker/my-worker/test/telegram.spec.ts
+++ b/worker/my-worker/test/telegram.spec.ts
@@ -2,6 +2,7 @@ import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import worker from '../src';
 import { tr } from '../src/translations';
+import { loadData } from '../src/data';
 
 env.AES_KEY = 'MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=';
 env.ADMIN_ID = '1';
@@ -55,11 +56,7 @@ describe('POST /telegram', () => {
     expect(mockFetch.mock.calls[0][0]).toBe(TELEGRAM_URL);
     expect(body.text).toBe('Product added');
 
-    const dataReq = new Request('http://example.com/data');
-    const ctx2 = createExecutionContext();
-    const resp2 = await worker.fetch(dataReq, env, ctx2);
-    await waitOnExecutionContext(ctx2);
-    const data = await resp2.json();
+    const data = await loadData(env);
     expect(data.products.p1.price).toBe('10');
     expect(data.products.p1.username).toBe('user');
   });
@@ -88,11 +85,7 @@ describe('POST /telegram', () => {
     const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
     expect(body.text).toBe(tr('welcome', 'en'));
 
-    const dataReq = new Request('http://example.com/data');
-    const ctx2 = createExecutionContext();
-    const resp2 = await worker.fetch(dataReq, env, ctx2);
-    await waitOnExecutionContext(ctx2);
-    const data = await resp2.json();
+    const data = await loadData(env);
     expect(data.products).toEqual({});
   });
 });


### PR DESCRIPTION
## Summary
- remove the `/data` endpoint
- update tests to use `loadData`/`saveData` helpers directly

## Testing
- `npm test --prefix worker/my-worker`

------
https://chatgpt.com/codex/tasks/task_e_6877a4ad87c0832da3a01a5f6900d3eb