### PR TITLE
Fix wrangler build recursion

### DIFF
--- a/worker/my-worker/package.json
+++ b/worker/my-worker/package.json
@@ -7,9 +7,10 @@
 		"dev": "wrangler dev",
 		"start": "wrangler dev",
 		"test": "vitest",
-		"cf-typegen": "wrangler types",
-		"build": "wrangler build"
-	},
+                "cf-typegen": "wrangler types",
+                "build": "wrangler build",
+                "compile": "tsc"
+        },
 	"devDependencies": {
 		"@cloudflare/vitest-pool-workers": "^0.8.19",
 		"typescript": "^5.5.2",

--- a/worker/my-worker/wrangler.toml
+++ b/worker/my-worker/wrangler.toml
@@ -6,7 +6,7 @@ compatibility_date = "2024-11-11"
 route = "https://example.com/*"
 
 [build]
-command = "npm run build"
+command = "npm run compile"
 
 
 [[d1_databases]]


### PR DESCRIPTION
## Summary
- run TypeScript compiler during Wrangler builds
- add `compile` npm script

## Testing
- `npm test`
- `npx -y wrangler@4.24.3 deploy --dry-run` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877aa882c28832d8512e1a6afdac1ba