### PR TITLE
Remove deprecated FERNET_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,6 @@ To deploy the Worker:
   wrangler secret put ADMIN_PHONE
   wrangler secret put AES_KEY
   ```
-   The Worker still accepts `FERNET_KEY` for compatibility but this variable is
-   deprecated and will be removed in a future release.
 7. Deploy the Worker by running `wrangler deploy` (or `npm run deploy`).
 8. After deployment, set the Telegram webhook to point to the Worker route:
    ```bash

--- a/worker/my-worker/src/data.ts
+++ b/worker/my-worker/src/data.ts
@@ -12,9 +12,9 @@ export async function loadData(env: Env): Promise<Data> {
 		const buyers = row.buyers ? JSON.parse(row.buyers) : [];
 		data.products[row.id] = {
 			price: row.price,
-			username: await decryptField(row.username, env.AES_KEY || env.FERNET_KEY),
-			password: await decryptField(row.password, env.AES_KEY || env.FERNET_KEY),
-			secret: await decryptField(row.secret, env.AES_KEY || env.FERNET_KEY),
+                        username: await decryptField(row.username, env.AES_KEY),
+                        password: await decryptField(row.password, env.AES_KEY),
+                        secret: await decryptField(row.secret, env.AES_KEY),
 			buyers,
 		};
 		if (row.name) data.products[row.id].name = row.name;
@@ -59,10 +59,9 @@ export async function saveData(env: Env, data: Data): Promise<void> {
 
 	for (const [id, product] of Object.entries(data.products)) {
 		prodIds.delete(id);
-		const key = env.AES_KEY || env.FERNET_KEY;
-		const encUser = await encryptField(product.username, key);
-		const encPass = await encryptField(product.password, key);
-		const encSecret = await encryptField(product.secret, key);
+                const encUser = await encryptField(product.username, env.AES_KEY);
+                const encPass = await encryptField(product.password, env.AES_KEY);
+                const encSecret = await encryptField(product.secret, env.AES_KEY);
 		const buyers = JSON.stringify(product.buyers || []);
 		statements.push(
 			env.DB.prepare(

--- a/worker/my-worker/src/env.ts
+++ b/worker/my-worker/src/env.ts
@@ -4,10 +4,8 @@ export interface Env {
   ADMIN_PHONE: string;
   /**
    * Base64 encoded AES key used for encrypting credentials.
-   * `FERNET_KEY` is still supported for backward compatibility.
    */
   AES_KEY: string;
-  FERNET_KEY?: string;
   DB: D1Database;
   PROOFS: R2Bucket;
 }


### PR DESCRIPTION
## Summary
- drop support for `FERNET_KEY`
- use `AES_KEY` exclusively for encryption

## Testing
- `npm install --silent`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6877b3dc612c832da317cd1d9adc3670