### PR TITLE
Add TOTP endpoint integration test

### DIFF
--- a/worker/my-worker/test/totp.spec.ts
+++ b/worker/my-worker/test/totp.spec.ts
@@ -1,0 +1,16 @@
+import { SELF } from 'cloudflare:test';
+import { describe, it, expect } from 'vitest';
+import { authenticator } from 'otplib';
+
+const SECRET = 'JBSWY3DPEHPK3PXP';
+
+describe('/totp route', () => {
+  it('returns an authenticator code', async () => {
+    const req = new Request(`http://example.com/totp?secret=${SECRET}`);
+    const res = await SELF.fetch(req);
+    const text = await res.text();
+    expect(res.status).toBe(200);
+    expect(text).toMatch(/^\d{6}$/);
+    expect(text).toBe(authenticator.generate(SECRET));
+  });
+});


### PR DESCRIPTION
## Summary
- add a new spec for the `/totp` route
- verify the worker returns a 6-digit authenticator code

## Testing
- `npx wrangler d1 migrations apply account-bot --local`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6877c181c754832d9095cb31759904f4