### PR TITLE
Secure TOTP endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ A Telegram bot for selling products with manual payment approval and two-factor 
 - Stats for each product are available with `/stats`.
 - Users can view the admin phone number with `/contact`.
 - Users can get a list of all commands with `/help`.
-- The Worker exposes `/totp` for generating authenticator codes.
+- The Worker exposes `/totp` for generating authenticator codes. This endpoint
+  requires a shared key when enabled.
 - Users may switch language from the main menu through the "Language" button or via `/setlang`. Bot messages support both English and Farsi.
 - پشتیبانی از منوهای سلسله‌مراتبی با دکمه‌های تلگرامی.
 - دکمه «بازگشت» و دکمه‌های جدید مدیریتی به منو افزوده شده‌اند.
@@ -134,13 +135,16 @@ Once the webhook is configured, Telegram will deliver updates to the `/telegram`
 endpoint of your Worker.
 
 ### `/totp` route
-Generate an authenticator code with a simple GET request:
+Generate an authenticator code with a GET request when the route is enabled:
 
 ```bash
-https://<worker-domain>/totp?secret=YOUR_SECRET
+https://<worker-domain>/totp?secret=YOUR_SECRET&key=YOUR_SHARED_KEY
 ```
 
-This relies on the Worker's installed `otplib` library to compute the TOTP.
+The request must include the `key` query parameter matching the `TOTP_KEY`
+environment variable. If `TOTP_KEY` is unset, the route is disabled. Keep this
+key private&mdash;anyone who can access `/totp` may generate valid TOTP codes
+for stored accounts.
 
 ## Wrangler Commands
 

--- a/worker/my-worker/public/index.html
+++ b/worker/my-worker/public/index.html
@@ -8,6 +8,6 @@
 <body>
     <h1>Account Seller Bot Worker</h1>
     <p>This Cloudflare Worker powers the Telegram bot.</p>
-    <p>Use <code>/totp?secret=YOUR_SECRET</code> to generate a temporary code.</p>
+    <p>Use <code>/totp?secret=YOUR_SECRET&amp;key=YOUR_SHARED_KEY</code> to generate a temporary code.</p>
 </body>
 </html>

--- a/worker/my-worker/src/env.ts
+++ b/worker/my-worker/src/env.ts
@@ -8,4 +8,9 @@ export interface Env {
   AES_KEY: string;
   DB: D1Database;
   PROOFS: R2Bucket;
+  /**
+   * Shared key required to access the `/totp` route.
+   * Leave unset to disable this endpoint in production.
+   */
+  TOTP_KEY?: string;
 }

--- a/worker/my-worker/src/index.ts
+++ b/worker/my-worker/src/index.ts
@@ -26,6 +26,13 @@ export default {
                 const url = new URL(request.url);
                 switch (url.pathname) {
                         case '/totp':
+                                if (!env.TOTP_KEY) {
+                                        return new Response('Not Found', { status: 404 });
+                                }
+                                const key = url.searchParams.get('key');
+                                if (key !== env.TOTP_KEY) {
+                                        return new Response('Unauthorized', { status: 401 });
+                                }
                                 const secret = url.searchParams.get('secret');
                                 if (!secret) {
                                         return new Response('Bad Request', { status: 400 });

--- a/worker/my-worker/test/totp.spec.ts
+++ b/worker/my-worker/test/totp.spec.ts
@@ -1,13 +1,17 @@
-import { SELF } from 'cloudflare:test';
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
 import { describe, it, expect } from 'vitest';
+import worker from '../src';
 import { authenticator } from 'otplib';
 
 const SECRET = 'JBSWY3DPEHPK3PXP';
+env.TOTP_KEY = 'TESTKEY';
 
 describe('/totp route', () => {
   it('returns an authenticator code', async () => {
-    const req = new Request(`http://example.com/totp?secret=${SECRET}`);
-    const res = await SELF.fetch(req);
+    const req = new Request(`http://example.com/totp?secret=${SECRET}&key=${env.TOTP_KEY}`);
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, env, ctx);
+    await waitOnExecutionContext(ctx);
     const text = await res.text();
     expect(res.status).toBe(200);
     expect(text).toMatch(/^\d{6}$/);


### PR DESCRIPTION
## Summary
- require `TOTP_KEY` before serving `/totp`
- add regression test for authorized access
- document security considerations in README
- show the shared-key requirement on the Worker index page

## Testing
- `npm --prefix worker/my-worker test`

------
https://chatgpt.com/codex/tasks/task_e_6877cd8eb220832da73bc8bb78c3f05a