### PR TITLE
Improve JSON handling for /telegram route

### DIFF
--- a/worker/my-worker/src/index.ts
+++ b/worker/my-worker/src/index.ts
@@ -42,7 +42,12 @@ export default {
                                 if (request.method !== 'POST') {
                                         return new Response('Method Not Allowed', { status: 405 });
                                 }
-                                const update: TelegramUpdate = await request.json();
+                                let update: TelegramUpdate;
+                                try {
+                                        update = await request.json();
+                                } catch {
+                                        return new Response('Bad Request', { status: 400 });
+                                }
                                 const text = update.message?.text;
                                 if (text) {
                                         const command = text.split(/\s+/)[0] as keyof typeof commandHandlers;

--- a/worker/my-worker/test/index.spec.ts
+++ b/worker/my-worker/test/index.spec.ts
@@ -18,8 +18,22 @@ describe('Hello World user worker', () => {
 			const request = new Request('http://example.com/message');
 			const response = await SELF.fetch(request);
 			expect(await response.text()).toMatchInlineSnapshot(`"Hello, World!"`);
-		});
-	});
+        });
+});
+
+describe('POST /telegram', () => {
+  it('returns 400 for invalid JSON body', async () => {
+    const req = new Request('http://example.com/telegram', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{bad json',
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(400);
+  });
+});
 
 	describe('request for /random', () => {
     it.skip('/ responds with a random UUID (unit style)', async () => {


### PR DESCRIPTION
## Summary
- return a 400 response when `/telegram` receives bad JSON
- add a unit test for JSON parsing failure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877d600a100832db5054f0ecd62ddbc