### PR TITLE
Add environment validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,22 @@ To deploy the Worker:
    create one with:
 
    ```bash
-   openssl rand -base64 32
-   ```
-   Copy the output and save it for the next step.
+  openssl rand -base64 32
+  ```
+  Copy the output and save it for the next step.
+
+### Required environment variables
+
+Set the following secrets and bindings for the Worker:
+
+| Variable | Description |
+| -------- | ----------- |
+| `BOT_TOKEN` | Telegram bot token |
+| `ADMIN_ID` | Telegram user ID of the admin |
+| `ADMIN_PHONE` | Phone number shown when users run `/contact` |
+| `AES_KEY` | Base64 AES key for encrypting credentials |
+| `DB` | Cloudflare D1 database binding |
+| `PROOFS` | Cloudflare R2 bucket for uploaded proofs |
 
 6. From the `worker/my-worker` directory, set the required secrets:
   ```bash

--- a/worker/my-worker/src/env.ts
+++ b/worker/my-worker/src/env.ts
@@ -14,3 +14,16 @@ export interface Env {
    */
   TOTP_KEY?: string;
 }
+
+export function validateEnv(env: Env): void {
+  const missing: string[] = [];
+  if (!env.BOT_TOKEN) missing.push('BOT_TOKEN');
+  if (!env.ADMIN_ID) missing.push('ADMIN_ID');
+  if (!env.ADMIN_PHONE) missing.push('ADMIN_PHONE');
+  if (!env.AES_KEY) missing.push('AES_KEY');
+  if (!env.DB) missing.push('DB');
+  if (!env.PROOFS) missing.push('PROOFS');
+  if (missing.length) {
+    throw new Error(`Missing environment bindings: ${missing.join(', ')}`);
+  }
+}

--- a/worker/my-worker/src/index.ts
+++ b/worker/my-worker/src/index.ts
@@ -13,6 +13,7 @@
  */
 
 import type { Env } from './env';
+import { validateEnv } from './env';
 import type { TelegramUpdate } from './telegram-utils';
 import { handlePhoto } from './telegram-utils';
 import { commandHandlers, handlePendingAddMessage, handlePendingEditMessage } from './telegram-commands';
@@ -23,6 +24,11 @@ import { authenticator } from 'otplib';
 
 export default {
         async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+                try {
+                        validateEnv(env);
+                } catch (err) {
+                        return new Response((err as Error).message, { status: 500 });
+                }
                 const url = new URL(request.url);
                 switch (url.pathname) {
                         case '/totp':

--- a/worker/my-worker/test/setup.ts
+++ b/worker/my-worker/test/setup.ts
@@ -1,6 +1,12 @@
 import { env } from 'cloudflare:test';
 import { beforeEach } from 'vitest';
 
+// Provide defaults required by the worker
+env.BOT_TOKEN ??= 'TEST';
+env.ADMIN_ID ??= '1';
+env.ADMIN_PHONE ??= '+10000000000';
+env.AES_KEY ??= 'MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=';
+
 // Ensure D1 and R2 are cleared between tests
 beforeEach(async () => {
   const stmts = [


### PR DESCRIPTION
## Summary
- verify required bindings in the worker using a helper
- return an error if any env vars are missing
- provide defaults for tests
- document required variables in README

## Testing
- `npm test --silent --prefix worker/my-worker`

------
https://chatgpt.com/codex/tasks/task_e_6877dd54cd8c832d82c490269a6df2af