### PR TITLE
Clarify route settings in worker config

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,7 @@
    npm install -g wrangler
    wrangler login
    ```
-2. ویرایش فایل `wrangler.toml` و جایگزین کردن شناسه‌ها با مقادیر حساب Cloudflare خود.
+2. ویرایش فایل `wrangler.toml` و جایگزین کردن شناسه‌ها با مقادیر حساب Cloudflare خود. خط `route` نمونه را با مسیر واقعی Worker جایگزین کنید یا در صورت نیاز آن را حذف کنید (مثال: `route = "https://example.com/*"`).
 3. ایجاد پایگاه داده D1:
    ```bash
    wrangler d1 create account-bot

--- a/worker/my-worker/wrangler.toml
+++ b/worker/my-worker/wrangler.toml
@@ -3,7 +3,7 @@ account_id = "1234567890abcdef1234567890abcdef" # placeholder - use your real Cl
 main = "src/index.ts"
 compatibility_date = "2024-11-11"
 
-route = "https://example.com/*"
+route = "https://example.com/*" # remove or replace with your real Worker route before deploy
 
 [build]
 command = "npm run compile"


### PR DESCRIPTION
## Summary
- document how to set the `route` entry in the worker config
- note that the example route should be removed or replaced before deployment

## Testing
- `npm install`
- `npx vitest run` *(fails: expected null to be undefined, first is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_687807c29704832dbd591210e1e459a7