### PR TITLE
Fix start menu and admin id

### DIFF
--- a/worker/my-worker/src/telegram-callbacks.ts
+++ b/worker/my-worker/src/telegram-callbacks.ts
@@ -12,6 +12,8 @@ import {
   buildAdminMenu,
   buildProductsMenu,
   isAdmin,
+  getSenderId,
+  getChatId,
   InlineKeyboardButton,
   CallbackHandler,
   TelegramUpdate
@@ -20,8 +22,9 @@ import {
 // --- Callback handlers ---
 
 export async function menuCallback(update: TelegramUpdate, env: Env): Promise<void> {
-  const chatId = update.callback_query?.message?.chat.id;
+  const chatId = getChatId(update);
   if (!chatId) return;
+  const userId = getSenderId(update);
   const lang = await userLang(env, chatId);
   const action = update.callback_query?.data.split(':')[1];
   if (action === 'language') {
@@ -39,7 +42,7 @@ export async function menuCallback(update: TelegramUpdate, env: Env): Promise<vo
         env,
         chatId,
         tr('welcome', lang),
-        buildMainMenu(lang, isAdmin(env, chatId)),
+        buildMainMenu(lang, userId !== undefined && isAdmin(env, userId)),
       );
       break;
     case 'products': {
@@ -93,7 +96,7 @@ export async function menuCallback(update: TelegramUpdate, env: Env): Promise<vo
       break;
     }
     case 'admin':
-      if (!isAdmin(env, chatId)) {
+      if (userId === undefined || !isAdmin(env, userId)) {
         await sendMessage(env, chatId, tr('unauthorized', lang), buildBackMenu(lang));
         return;
       }
@@ -144,8 +147,9 @@ export async function codeCallback(update: TelegramUpdate, env: Env): Promise<vo
 }
 
 export async function languageMenuCallback(update: TelegramUpdate, env: Env): Promise<void> {
-  const chatId = update.callback_query?.message?.chat.id;
+  const chatId = getChatId(update);
   if (!chatId) return;
+  const userId = getSenderId(update);
   const dataStr = update.callback_query?.data || '';
   const parts = dataStr.split(':');
   const lang = await userLang(env, chatId);
@@ -162,15 +166,16 @@ export async function languageMenuCallback(update: TelegramUpdate, env: Env): Pr
     env,
     chatId,
     tr('language_set', langCode),
-    buildMainMenu(langCode, isAdmin(env, chatId)),
+    buildMainMenu(langCode, userId !== undefined && isAdmin(env, userId)),
   );
 }
 
 export async function adminMenuCallback(update: TelegramUpdate, env: Env): Promise<void> {
-  const chatId = update.callback_query?.message?.chat.id;
+  const chatId = getChatId(update);
   if (!chatId) return;
+  const userId = getSenderId(update);
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (userId === undefined || !isAdmin(env, userId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -269,10 +274,11 @@ export async function adminMenuCallback(update: TelegramUpdate, env: Env): Promi
 }
 
 export async function adminCallback(update: TelegramUpdate, env: Env): Promise<void> {
-  const chatId = update.callback_query?.message?.chat.id;
+  const chatId = getChatId(update);
   if (!chatId) return;
+  const userId = getSenderId(update);
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (userId === undefined || !isAdmin(env, userId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -327,10 +333,11 @@ export async function adminCallback(update: TelegramUpdate, env: Env): Promise<v
 }
 
 export async function editprodCallback(update: TelegramUpdate, env: Env): Promise<void> {
-  const chatId = update.callback_query?.message?.chat.id;
+  const chatId = getChatId(update);
   if (!chatId) return;
+  const userId = getSenderId(update);
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (userId === undefined || !isAdmin(env, userId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -346,9 +353,11 @@ export async function editprodCallback(update: TelegramUpdate, env: Env): Promis
 }
 
 export async function editfieldCallback(update: TelegramUpdate, env: Env): Promise<void> {
-  const chatId = update.callback_query?.message?.chat.id;
+  const chatId = getChatId(update);
   if (!chatId) return;
+  const userId = getSenderId(update);
   const lang = await userLang(env, chatId);
+  if (userId === undefined) return;
   const parts = update.callback_query?.data.split(':') || [];
   const pid = parts[1];
   const field = parts[2];
@@ -356,10 +365,11 @@ export async function editfieldCallback(update: TelegramUpdate, env: Env): Promi
 }
 
 export async function buyerlistCallback(update: TelegramUpdate, env: Env): Promise<void> {
-  const chatId = update.callback_query?.message?.chat.id;
+  const chatId = getChatId(update);
   if (!chatId) return;
+  const userId = getSenderId(update);
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (userId === undefined || !isAdmin(env, userId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -382,10 +392,11 @@ export async function buyerlistCallback(update: TelegramUpdate, env: Env): Promi
 }
 
 export async function clearbuyersCallback(update: TelegramUpdate, env: Env): Promise<void> {
-  const chatId = update.callback_query?.message?.chat.id;
+  const chatId = getChatId(update);
   if (!chatId) return;
+  const userId = getSenderId(update);
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (userId === undefined || !isAdmin(env, userId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -402,10 +413,11 @@ export async function clearbuyersCallback(update: TelegramUpdate, env: Env): Pro
 }
 
 export async function resendCallback(update: TelegramUpdate, env: Env): Promise<void> {
-  const chatId = update.callback_query?.message?.chat.id;
+  const chatId = getChatId(update);
   if (!chatId) return;
+  const userId = getSenderId(update);
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (userId === undefined || !isAdmin(env, userId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -446,10 +458,11 @@ export async function resendCallback(update: TelegramUpdate, env: Env): Promise<
 }
 
 export async function deleteprodCallback(update: TelegramUpdate, env: Env): Promise<void> {
-  const chatId = update.callback_query?.message?.chat.id;
+  const chatId = getChatId(update);
   if (!chatId) return;
+  const userId = getSenderId(update);
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (userId === undefined || !isAdmin(env, userId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }

--- a/worker/my-worker/src/telegram-commands.ts
+++ b/worker/my-worker/src/telegram-commands.ts
@@ -30,14 +30,22 @@ import {
   buildAdminMenu,
   buildProductsMenu,
   SUPPORTED_LANGS,
-  isAdmin
+  isAdmin,
+  getSenderId,
+  getChatId
 } from "./telegram-utils";
 
 export async function handleStart(update: TelegramUpdate, env: Env): Promise<void> {
-  const chatId = update.message?.chat.id;
+  const chatId = getChatId(update);
   if (!chatId) return;
+  const userId = getSenderId(update);
   const lang = await userLang(env, chatId);
-  await sendMessage(env, chatId, tr('welcome', lang));
+  await sendMessage(
+    env,
+    chatId,
+    tr('welcome', lang),
+    buildMainMenu(lang, userId !== undefined && isAdmin(env, userId)),
+  );
 }
 
 export async function handleProducts(update: TelegramUpdate, env: Env): Promise<void> {
@@ -196,10 +204,11 @@ async function continueEditFlow(update: TelegramUpdate, env: Env): Promise<void>
 }
 
 export async function handleAddProduct(update: TelegramUpdate, env: Env): Promise<void> {
-  const chatId = update.message?.chat.id;
+  const chatId = getChatId(update);
   if (!chatId) return;
+  const userId = getSenderId(update);
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (userId === undefined || !isAdmin(env, userId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -225,10 +234,11 @@ export async function handleAddProduct(update: TelegramUpdate, env: Env): Promis
 }
 
 export async function handlePending(update: TelegramUpdate, env: Env): Promise<void> {
-  const chatId = update.message?.chat.id;
+  const chatId = getChatId(update);
   if (!chatId) return;
+  const userId = getSenderId(update);
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (userId === undefined || !isAdmin(env, userId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -246,10 +256,11 @@ export async function handlePending(update: TelegramUpdate, env: Env): Promise<v
 }
 
 export async function handleStats(update: TelegramUpdate, env: Env): Promise<void> {
-  const chatId = update.message?.chat.id;
+  const chatId = getChatId(update);
   if (!chatId) return;
+  const userId = getSenderId(update);
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (userId === undefined || !isAdmin(env, userId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -273,10 +284,11 @@ export async function handleStats(update: TelegramUpdate, env: Env): Promise<voi
 }
 
 export async function handleBuyers(update: TelegramUpdate, env: Env): Promise<void> {
-  const chatId = update.message?.chat.id;
+  const chatId = getChatId(update);
   if (!chatId) return;
+  const userId = getSenderId(update);
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (userId === undefined || !isAdmin(env, userId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -304,7 +316,7 @@ export async function handleBuyers(update: TelegramUpdate, env: Env): Promise<vo
 }
 
 export async function handleSetLang(update: TelegramUpdate, env: Env): Promise<void> {
-  const chatId = update.message?.chat.id;
+  const chatId = getChatId(update);
   if (!chatId) return;
   const dataText = update.message?.text || '';
   const args = dataText.split(/\s+/).slice(1);
@@ -323,10 +335,11 @@ export async function handleSetLang(update: TelegramUpdate, env: Env): Promise<v
 }
 
 export async function handleApprove(update: TelegramUpdate, env: Env): Promise<void> {
-  const chatId = update.message?.chat.id;
+  const chatId = getChatId(update);
   if (!chatId) return;
+  const userIdAdmin = getSenderId(update);
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (userIdAdmin === undefined || !isAdmin(env, userIdAdmin)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -358,10 +371,11 @@ export async function handleApprove(update: TelegramUpdate, env: Env): Promise<v
 }
 
 export async function handleReject(update: TelegramUpdate, env: Env): Promise<void> {
-  const chatId = update.message?.chat.id;
+  const chatId = getChatId(update);
   if (!chatId) return;
+  const userIdAdmin = getSenderId(update);
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (userIdAdmin === undefined || !isAdmin(env, userIdAdmin)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -409,10 +423,11 @@ export async function handleCode(update: TelegramUpdate, env: Env): Promise<void
 }
 
 export async function handleEditProduct(update: TelegramUpdate, env: Env): Promise<void> {
-  const chatId = update.message?.chat.id;
+  const chatId = getChatId(update);
   if (!chatId) return;
+  const userId = getSenderId(update);
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (userId === undefined || !isAdmin(env, userId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -438,10 +453,11 @@ export async function handleEditProduct(update: TelegramUpdate, env: Env): Promi
 }
 
 export async function handleDeleteProduct(update: TelegramUpdate, env: Env): Promise<void> {
-  const chatId = update.message?.chat.id;
+  const chatId = getChatId(update);
   if (!chatId) return;
+  const userId = getSenderId(update);
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (userId === undefined || !isAdmin(env, userId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -460,10 +476,11 @@ export async function handleDeleteProduct(update: TelegramUpdate, env: Env): Pro
 }
 
 export async function handleDeleteBuyer(update: TelegramUpdate, env: Env): Promise<void> {
-  const chatId = update.message?.chat.id;
+  const chatId = getChatId(update);
   if (!chatId) return;
+  const userId = getSenderId(update);
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (userId === undefined || !isAdmin(env, userId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -490,10 +507,11 @@ export async function handleDeleteBuyer(update: TelegramUpdate, env: Env): Promi
 }
 
 export async function handleClearBuyers(update: TelegramUpdate, env: Env): Promise<void> {
-  const chatId = update.message?.chat.id;
+  const chatId = getChatId(update);
   if (!chatId) return;
+  const userId = getSenderId(update);
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (userId === undefined || !isAdmin(env, userId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -512,10 +530,11 @@ export async function handleClearBuyers(update: TelegramUpdate, env: Env): Promi
 }
 
 export async function handleResend(update: TelegramUpdate, env: Env): Promise<void> {
-  const chatId = update.message?.chat.id;
+  const chatId = getChatId(update);
   if (!chatId) return;
+  const userId = getSenderId(update);
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (userId === undefined || !isAdmin(env, userId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }

--- a/worker/my-worker/src/telegram-utils.ts
+++ b/worker/my-worker/src/telegram-utils.ts
@@ -13,6 +13,18 @@ export function isAdmin(env: Env, userId: number): boolean {
   return String(userId) === env.ADMIN_ID;
 }
 
+export function getSenderId(update: TelegramUpdate): number | undefined {
+  return (
+    update.message?.from?.id ??
+    update.callback_query?.from.id ??
+    update.message?.chat.id
+  );
+}
+
+export function getChatId(update: TelegramUpdate): number | undefined {
+  return update.message?.chat.id ?? update.callback_query?.message?.chat.id;
+}
+
 export interface InlineKeyboardButton {
   text: string;
   callback_data: string;
@@ -24,6 +36,7 @@ export interface InlineKeyboardMarkup {
 
 export interface TelegramMessage {
   chat: { id: number };
+  from?: { id: number };
   text?: string;
   photo?: { file_id: string }[];
 }


### PR DESCRIPTION
## Summary
- show main menu on `/start`
- derive user and chat IDs correctly
- check admin ID against sender rather than chat ID

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68781ea29f1c832dbc8355e1011ca1bd