### PR TITLE
Fix admin check to use sender ID

### DIFF
--- a/worker/my-worker/src/telegram-callbacks.ts
+++ b/worker/my-worker/src/telegram-callbacks.ts
@@ -22,6 +22,7 @@ import {
 export async function menuCallback(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.callback_query?.message?.chat.id;
   if (!chatId) return;
+  const senderId = update.callback_query?.from.id ?? chatId;
   const lang = await userLang(env, chatId);
   const action = update.callback_query?.data.split(':')[1];
   if (action === 'language') {
@@ -39,7 +40,7 @@ export async function menuCallback(update: TelegramUpdate, env: Env): Promise<vo
         env,
         chatId,
         tr('welcome', lang),
-        buildMainMenu(lang, isAdmin(env, chatId)),
+        buildMainMenu(lang, isAdmin(env, senderId)),
       );
       break;
     case 'products': {
@@ -92,8 +93,8 @@ export async function menuCallback(update: TelegramUpdate, env: Env): Promise<vo
       await sendMessage(env, chatId, text, buildBackMenu(lang));
       break;
     }
-    case 'admin':
-      if (!isAdmin(env, chatId)) {
+      case 'admin':
+        if (!isAdmin(env, senderId)) {
         await sendMessage(env, chatId, tr('unauthorized', lang), buildBackMenu(lang));
         return;
       }
@@ -146,6 +147,7 @@ export async function codeCallback(update: TelegramUpdate, env: Env): Promise<vo
 export async function languageMenuCallback(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.callback_query?.message?.chat.id;
   if (!chatId) return;
+  const senderId = update.callback_query?.from.id ?? chatId;
   const dataStr = update.callback_query?.data || '';
   const parts = dataStr.split(':');
   const lang = await userLang(env, chatId);
@@ -162,15 +164,16 @@ export async function languageMenuCallback(update: TelegramUpdate, env: Env): Pr
     env,
     chatId,
     tr('language_set', langCode),
-    buildMainMenu(langCode, isAdmin(env, chatId)),
+    buildMainMenu(langCode, isAdmin(env, senderId)),
   );
 }
 
 export async function adminMenuCallback(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.callback_query?.message?.chat.id;
   if (!chatId) return;
+  const senderId = update.callback_query?.from.id ?? chatId;
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (!isAdmin(env, senderId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -271,8 +274,9 @@ export async function adminMenuCallback(update: TelegramUpdate, env: Env): Promi
 export async function adminCallback(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.callback_query?.message?.chat.id;
   if (!chatId) return;
+  const senderId = update.callback_query?.from.id ?? chatId;
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (!isAdmin(env, senderId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -329,8 +333,9 @@ export async function adminCallback(update: TelegramUpdate, env: Env): Promise<v
 export async function editprodCallback(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.callback_query?.message?.chat.id;
   if (!chatId) return;
+  const senderId = update.callback_query?.from.id ?? chatId;
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (!isAdmin(env, senderId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -358,8 +363,9 @@ export async function editfieldCallback(update: TelegramUpdate, env: Env): Promi
 export async function buyerlistCallback(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.callback_query?.message?.chat.id;
   if (!chatId) return;
+  const senderId = update.callback_query?.from.id ?? chatId;
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (!isAdmin(env, senderId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -384,8 +390,9 @@ export async function buyerlistCallback(update: TelegramUpdate, env: Env): Promi
 export async function clearbuyersCallback(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.callback_query?.message?.chat.id;
   if (!chatId) return;
+  const senderId = update.callback_query?.from.id ?? chatId;
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (!isAdmin(env, senderId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -404,8 +411,9 @@ export async function clearbuyersCallback(update: TelegramUpdate, env: Env): Pro
 export async function resendCallback(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.callback_query?.message?.chat.id;
   if (!chatId) return;
+  const senderId = update.callback_query?.from.id ?? chatId;
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (!isAdmin(env, senderId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -448,8 +456,9 @@ export async function resendCallback(update: TelegramUpdate, env: Env): Promise<
 export async function deleteprodCallback(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.callback_query?.message?.chat.id;
   if (!chatId) return;
+  const senderId = update.callback_query?.from.id ?? chatId;
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (!isAdmin(env, senderId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }

--- a/worker/my-worker/src/telegram-commands.ts
+++ b/worker/my-worker/src/telegram-commands.ts
@@ -198,8 +198,9 @@ async function continueEditFlow(update: TelegramUpdate, env: Env): Promise<void>
 export async function handleAddProduct(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.message?.chat.id;
   if (!chatId) return;
+  const senderId = update.message?.from?.id ?? chatId;
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (!isAdmin(env, senderId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -227,8 +228,9 @@ export async function handleAddProduct(update: TelegramUpdate, env: Env): Promis
 export async function handlePending(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.message?.chat.id;
   if (!chatId) return;
+  const senderId = update.message?.from?.id ?? chatId;
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (!isAdmin(env, senderId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -248,8 +250,9 @@ export async function handlePending(update: TelegramUpdate, env: Env): Promise<v
 export async function handleStats(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.message?.chat.id;
   if (!chatId) return;
+  const senderId = update.message?.from?.id ?? chatId;
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (!isAdmin(env, senderId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -275,8 +278,9 @@ export async function handleStats(update: TelegramUpdate, env: Env): Promise<voi
 export async function handleBuyers(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.message?.chat.id;
   if (!chatId) return;
+  const senderId = update.message?.from?.id ?? chatId;
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (!isAdmin(env, senderId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -325,8 +329,9 @@ export async function handleSetLang(update: TelegramUpdate, env: Env): Promise<v
 export async function handleApprove(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.message?.chat.id;
   if (!chatId) return;
+  const senderId = update.message?.from?.id ?? chatId;
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (!isAdmin(env, senderId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -360,8 +365,9 @@ export async function handleApprove(update: TelegramUpdate, env: Env): Promise<v
 export async function handleReject(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.message?.chat.id;
   if (!chatId) return;
+  const senderId = update.message?.from?.id ?? chatId;
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (!isAdmin(env, senderId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -411,8 +417,9 @@ export async function handleCode(update: TelegramUpdate, env: Env): Promise<void
 export async function handleEditProduct(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.message?.chat.id;
   if (!chatId) return;
+  const senderId = update.message?.from?.id ?? chatId;
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (!isAdmin(env, senderId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -440,8 +447,9 @@ export async function handleEditProduct(update: TelegramUpdate, env: Env): Promi
 export async function handleDeleteProduct(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.message?.chat.id;
   if (!chatId) return;
+  const senderId = update.message?.from?.id ?? chatId;
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (!isAdmin(env, senderId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -462,8 +470,9 @@ export async function handleDeleteProduct(update: TelegramUpdate, env: Env): Pro
 export async function handleDeleteBuyer(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.message?.chat.id;
   if (!chatId) return;
+  const senderId = update.message?.from?.id ?? chatId;
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (!isAdmin(env, senderId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -492,8 +501,9 @@ export async function handleDeleteBuyer(update: TelegramUpdate, env: Env): Promi
 export async function handleClearBuyers(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.message?.chat.id;
   if (!chatId) return;
+  const senderId = update.message?.from?.id ?? chatId;
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (!isAdmin(env, senderId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }
@@ -514,8 +524,9 @@ export async function handleClearBuyers(update: TelegramUpdate, env: Env): Promi
 export async function handleResend(update: TelegramUpdate, env: Env): Promise<void> {
   const chatId = update.message?.chat.id;
   if (!chatId) return;
+  const senderId = update.message?.from?.id ?? chatId;
   const lang = await userLang(env, chatId);
-  if (!isAdmin(env, chatId)) {
+  if (!isAdmin(env, senderId)) {
     await sendMessage(env, chatId, tr('unauthorized', lang));
     return;
   }

--- a/worker/my-worker/test/add_conversation.spec.ts
+++ b/worker/my-worker/test/add_conversation.spec.ts
@@ -34,7 +34,7 @@ describe('interactive addproduct flow', () => {
 
   it('stores product after multi-step conversation', async () => {
     // start conversation
-    let update: any = { message: { chat: { id: 1 }, text: '/addproduct' } };
+    let update: any = { message: { chat: { id: 1 }, from: { id: 1 }, text: '/addproduct' } };
     let req = new Request('http://example.com/telegram', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -50,7 +50,7 @@ describe('interactive addproduct flow', () => {
     mockFetch.mockClear();
 
     // send id
-    update = { message: { chat: { id: 1 }, text: 'p1' } };
+    update = { message: { chat: { id: 1 }, from: { id: 1 }, text: 'p1' } };
     req = new Request('http://example.com/telegram', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -66,7 +66,7 @@ describe('interactive addproduct flow', () => {
     mockFetch.mockClear();
 
     // price
-    update = { message: { chat: { id: 1 }, text: '10' } };
+    update = { message: { chat: { id: 1 }, from: { id: 1 }, text: '10' } };
     req = new Request('http://example.com/telegram', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(update) });
     ctx = createExecutionContext();
     await worker.fetch(req, env, ctx);
@@ -76,7 +76,7 @@ describe('interactive addproduct flow', () => {
     mockFetch.mockClear();
 
     // username
-    update = { message: { chat: { id: 1 }, text: 'user' } };
+    update = { message: { chat: { id: 1 }, from: { id: 1 }, text: 'user' } };
     req = new Request('http://example.com/telegram', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(update) });
     ctx = createExecutionContext();
     await worker.fetch(req, env, ctx);
@@ -86,7 +86,7 @@ describe('interactive addproduct flow', () => {
     mockFetch.mockClear();
 
     // password
-    update = { message: { chat: { id: 1 }, text: 'pass' } };
+    update = { message: { chat: { id: 1 }, from: { id: 1 }, text: 'pass' } };
     req = new Request('http://example.com/telegram', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(update) });
     ctx = createExecutionContext();
     await worker.fetch(req, env, ctx);
@@ -96,7 +96,7 @@ describe('interactive addproduct flow', () => {
     mockFetch.mockClear();
 
     // secret
-    update = { message: { chat: { id: 1 }, text: 'sec' } };
+    update = { message: { chat: { id: 1 }, from: { id: 1 }, text: 'sec' } };
     req = new Request('http://example.com/telegram', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(update) });
     ctx = createExecutionContext();
     await worker.fetch(req, env, ctx);
@@ -106,7 +106,7 @@ describe('interactive addproduct flow', () => {
     mockFetch.mockClear();
 
     // name
-    update = { message: { chat: { id: 1 }, text: 'TestProd' } };
+    update = { message: { chat: { id: 1 }, from: { id: 1 }, text: 'TestProd' } };
     req = new Request('http://example.com/telegram', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(update) });
     ctx = createExecutionContext();
     await worker.fetch(req, env, ctx);

--- a/worker/my-worker/test/edit_buttons.spec.ts
+++ b/worker/my-worker/test/edit_buttons.spec.ts
@@ -77,7 +77,7 @@ describe('interactive edit buttons flow', () => {
     mockFetch.mockClear();
 
     // send new value
-    update = { message: { chat: { id: 1 }, text: '2' } };
+    update = { message: { chat: { id: 1 }, from: { id: 1 }, text: '2' } };
     req = new Request('http://example.com/telegram', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(update) });
     ctx = createExecutionContext();
     await worker.fetch(req, env, ctx);

--- a/worker/my-worker/test/edit_conversation.spec.ts
+++ b/worker/my-worker/test/edit_conversation.spec.ts
@@ -51,7 +51,7 @@ describe('interactive editproduct flow', () => {
     mockFetch.mockClear();
 
     // send new value
-    update = { message: { chat: { id: 1 }, text: '2' } };
+    update = { message: { chat: { id: 1 }, from: { id: 1 }, text: '2' } };
     req = new Request('http://example.com/telegram', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(update) });
     ctx = createExecutionContext();
     await worker.fetch(req, env, ctx);

--- a/worker/my-worker/test/pending.spec.ts
+++ b/worker/my-worker/test/pending.spec.ts
@@ -29,7 +29,7 @@ describe('pending command', () => {
     await env.DB.exec(`INSERT INTO products (id, price, username, password, secret, name, buyers) VALUES ('p1','10','${encUser}','${encPass}','${encSecret}',NULL,'[]')`);
     await env.DB.exec("INSERT INTO pending (user_id, product_id) VALUES (2, 'p1')");
 
-    const update = { message: { chat: { id: 1 }, text: '/pending' } };
+    const update = { message: { chat: { id: 1 }, from: { id: 1 }, text: '/pending' } };
     const req = new Request('http://example.com/telegram', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },

--- a/worker/my-worker/test/telegram.spec.ts
+++ b/worker/my-worker/test/telegram.spec.ts
@@ -37,6 +37,7 @@ describe('POST /telegram', () => {
     const update = {
       message: {
         chat: { id: 1 },
+        from: { id: 1 },
         text: '/addproduct p1 10 user pass sec TestProd',
       },
     };


### PR DESCRIPTION
## Summary
- use sender's ID for `isAdmin` checks
- update Telegram callback handlers accordingly
- adjust test updates to include `from` field

## Testing
- `npx vitest run` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_688225383334832da625720b0120d6d0